### PR TITLE
fix: overrides not working for plasmoids in system tray

### DIFF
--- a/package/contents/ui/code/utils.js
+++ b/package/contents/ui/code/utils.js
@@ -155,7 +155,7 @@ function findWidgetsTray(grid, panelWidgets) {
 }
 
 function getWidgetNameAndId(item) {
-  let name = null
+  let name = ""
   let id = -1
   if (item.applet?.plasmoid?.pluginName) {
     name = item.applet.plasmoid.pluginName
@@ -168,8 +168,8 @@ function getWidgetNameAndId(item) {
         name = model.Id
       } else if (model.itemType === "Plasmoid") {
         const applet = model.applet ?? null
-        name = applet?.plasmoid.pluginName ?? null
-        name = applet?.plasmoid.id ?? -1
+        name = applet?.plasmoid.pluginName ?? ""
+        id = applet?.plasmoid.id ?? -1
       }
     }
   }


### PR DESCRIPTION
before trying to apply the foreground color, we need to know if we
have changed it in the first place, otherwise we have no easy way to
restore the original binding for widgets that do dynamic color
requires restarting plasma but is better than nothing