### PR TITLE
fix: target current panel by id when changing stock panel settings

### DIFF
--- a/package/contents/ui/code/utils.js
+++ b/package/contents/ui/code/utils.js
@@ -417,59 +417,31 @@ function getWidgetRootDir() {
   return path.join('/')
 }
 
-function getPanelPosition() {
-  var location
-  var screen = main.screen
-
-  switch (plasmoid.location) {
-    case PlasmaCore.Types.TopEdge:
-      location = "top"
-      break
-    case PlasmaCore.Types.BottomEdge:
-      location = "bottom"
-      break
-    case PlasmaCore.Types.LeftEdge:
-      location = "left"
-      break
-    case PlasmaCore.Types.RightEdge:
-      location = "right"
-      break
-  }
-
-  console.log("location:" + location + " screen:" + screen);
-  return { "screen": screen, "location": location }
-}
-
-function setPanelModeScript(panelPosition, panelSettings) {
+function setPanelModeScript(panelId, panelSettings) {
   var setPanelModeScript = `
-for (var id of panelIds) {
-  var panel = panelById(id);
-  if (panel.screen === ${panelPosition.screen} && panel.location === "${panelPosition.location}" ) {
-    if (${panelSettings.visibility.enabled}) {
-      panel.hiding = "${panelSettings.visibility.value}"
-    }
-    if (${panelSettings.thickness.enabled}) {
-      panel.height = ${panelSettings.thickness.value}
-    }
-    if (${panelSettings.lengthMode.enabled}) {
-      panel.lengthMode = "${panelSettings.lengthMode.value}"
-    }
-    if (${panelSettings.position.enabled}) {
-      panel.location = "${panelSettings.position.value}"
-    }
-    if (${panelSettings.floating.enabled}) {
-      panel.floating = ${panelSettings.floating.value}
-    }
-    if (${panelSettings.alignment.enabled}) {
-      panel.alignment = "${panelSettings.alignment.value}"
-    }
-    if (${panelSettings.opacity.enabled}) {
-      panel.opacity = "${panelSettings.opacity.value}"
-    }
-    break
-  }
-}`
-  return setPanelModeScript
+var panel = panelById(${panelId});
+if (${panelSettings.visibility.enabled}) {
+  panel.hiding = "${panelSettings.visibility.value}"
+}
+if (${panelSettings.thickness.enabled}) {
+  panel.height = ${panelSettings.thickness.value}
+}
+if (${panelSettings.lengthMode.enabled}) {
+  panel.lengthMode = "${panelSettings.lengthMode.value}"
+}
+if (${panelSettings.position.enabled}) {
+  panel.location = "${panelSettings.position.value}"
+}
+if (${panelSettings.floating.enabled}) {
+  panel.floating = ${panelSettings.floating.value}
+}
+if (${panelSettings.alignment.enabled}) {
+  panel.alignment = "${panelSettings.alignment.value}"
+}
+if (${panelSettings.opacity.enabled}) {
+  panel.opacity = "${panelSettings.opacity.value}"
+}`;
+  return setPanelModeScript;
 }
 
 function evaluateScript(script) {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -25,26 +25,6 @@ PlasmoidItem {
     property int panelLayoutCount: panelLayout?.children?.length || 0
     property int trayGridViewCount: trayGridView?.count || 0
     property int trayGridViewCountOld: 0
-    property var panelPrefixes: ["north","south","west","east"]
-    property var panelPosition: {
-        var location
-        var screen = main.screen
-        switch (plasmoid.location) {
-            case PlasmaCore.Types.TopEdge:
-            location = "top"
-            break
-            case PlasmaCore.Types.BottomEdge:
-            location = "bottom"
-            break
-            case PlasmaCore.Types.LeftEdge:
-            location = "left"
-            break
-            case PlasmaCore.Types.RightEdge:
-            location = "right"
-            break
-        }
-        return { "screen": screen, "location": location }
-    }
     property bool horizontal: Plasmoid.formFactor === PlasmaCore.Types.Horizontal
     property bool editMode: Plasmoid.containment.corona?.editMode ?? false
     property bool onDesktop: plasmoid.location === PlasmaCore.Types.Floating
@@ -158,7 +138,7 @@ PlasmoidItem {
     onStockPanelSettingsChanged: {
         Qt.callLater(function() {
             // console.error(JSON.stringify(stockPanelSettings))
-            let script = Utils.setPanelModeScript(panelPosition, stockPanelSettings)
+            let script = Utils.setPanelModeScript(Plasmoid.containment.id, stockPanelSettings)
             if (stockPanelSettings.visible.enabled) {
                 panelView.visible = stockPanelSettings.visible.value
             } else {


### PR DESCRIPTION
before this change it was possible to target the wrong panel as only location and screen where checked