### PR TITLE
feat: add option to disable native panel background shadow

### DIFF
--- a/package/contents/ui/code/globals.js
+++ b/package/contents/ui/code/globals.js
@@ -249,6 +249,7 @@ const defaultConfig = {
   nativePanelBackground: {
     enabled: true,
     opacity: 1.0,
+    shadow: true,
   },
   stockPanelSettings: baseStockPanelSettings,
   configurationOverrides: {

--- a/package/contents/ui/components/FormWidgetSettings.qml
+++ b/package/contents/ui/components/FormWidgetSettings.qml
@@ -111,9 +111,29 @@ ColumnLayout {
 
             RowLayout {
                 visible: keyName === "panel"
+                enabled: nativePanelBackgroundCheckbox.checked
 
                 Label {
-                    text: i18n("Panel Opacity:")
+                    text: i18n("Native panel background shadow:")
+                }
+
+                CheckBox {
+                    id: nativePanelBackgroundShadowCheckbox
+
+                    checked: config.nativePanelBackground.shadow
+                    onCheckedChanged: {
+                        config.nativePanelBackground.shadow = checked;
+                        updateConfig();
+                    }
+                }
+            }
+
+            RowLayout {
+                visible: keyName === "panel"
+                enabled: nativePanelBackgroundCheckbox.checked
+
+                Label {
+                    text: i18n("Native panel background opacity:")
                 }
 
                 SpinBoxDecimal {
@@ -125,7 +145,6 @@ ColumnLayout {
                         config.nativePanelBackground.opacity = value;
                         updateConfig();
                     }
-                    enabled: nativePanelBackgroundCheckbox.checked
                 }
 
                 Kirigami.ContextualHelpButton {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -55,6 +55,7 @@ PlasmoidItem {
     property bool isEnabled: plasmoid.configuration.isEnabled
     property bool nativePanelBackgroundEnabled: (isEnabled ? cfg.nativePanelBackground.enabled : true) || doPanelClickFix
     property real nativePanelBackgroundOpacity: isEnabled ? cfg.nativePanelBackground.opacity : 1.0
+    property bool nativePanelBackgroundShadowEnabled: isEnabled ? cfg.nativePanelBackground.shadow : true
     property var panelWidgets: []
     property int panelWidgetsCount: panelWidgets?.length || 0
     property real trayItemThikness: 20
@@ -1173,6 +1174,20 @@ PlasmoidItem {
         property: "panelMask"
         value: blurMask
         when: (panelColorizer !== null && blurMask && panelColorizer?.hasRegions && (panelSettings.blurBehind || anyWidgetDoingBlur || anyTrayItemDoingBlur))
+    }
+
+    Binding {
+        target: panelElement
+        property: "topShadowMargin"
+        value: -panelView.height - 8
+        when: !nativePanelBackgroundShadowEnabled
+    }
+
+    Binding {
+        target: panelElement
+        property: "bottomShadowMargin"
+        value: -panelView.height - 8
+        when: !nativePanelBackgroundShadowEnabled
     }
 
     // The panel doesn't like having its spacings set to 0


### PR DESCRIPTION
This change doesn't actually remove the shadow, just overrides the margins so it renders off screen.

See https://github.com/KDE/plasma-workspace/blob/Plasma/6.3/shell/panelview.cpp#L488

refs: https://github.com/luisbocanegra/plasma-panel-colorizer/issues/59