### PR TITLE
fix: broken coloring in Plasma 6.3.4

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -442,11 +442,14 @@ PlasmoidItem {
             }
         }
         property bool throttleMaskUpdate: false
+        // `visible: false` breaks in Plasma 6.3.4, so we use `opacity: 0` instead
+        // https://github.com/luisbocanegra/plasma-panel-colorizer/issues/212
+        // https://bugs.kde.org/show_bug.cgi?id=502480
         Rectangle {
             id: fgColorHolder
             height: 6
             width: height
-            visible: false
+            opacity: 0
             radius: height / 2
             anchors.right: parent.right
             Kirigami.Theme.colorSet: Kirigami.Theme[fgColorCfg.systemColorSet]
@@ -455,7 +458,7 @@ PlasmoidItem {
             id: bgColorHolder
             height: 6
             width: height
-            visible: false
+            opacity: 0
             radius: height / 2
             anchors.right: parent.right
             Kirigami.Theme.colorSet: Kirigami.Theme[bgColorCfg.systemColorSet]


### PR DESCRIPTION
For some reason the colorHolders become black when their visibility is set to disabled, making them visible with opacity of 0 seems to get around this new behavior

Upstream bug report https://bugs.kde.org/show_bug.cgi?id=502480

refs: https://github.com/luisbocanegra/plasma-panel-colorizer/issues/212