### PR TITLE
fix: set AnimatedImage layer.live on onPlayingChanged

### DIFF
--- a/package/contents/ui/ImageRoundedRectangle.qml
+++ b/package/contents/ui/ImageRoundedRectangle.qml
@@ -16,7 +16,11 @@ AnimatedImage {
     asynchronous: true
     anchors.fill: parent
     layer.enabled: true
-    layer.live: true
+    // workaround for https://github.com/luisbocanegra/plasma-panel-colorizer/issues/232
+    // possibly https://bugreports.qt.io/browse/QTBUG-65463
+    onPlayingChanged: {
+        layer.live = playing;
+    }
     layer.effect: MultiEffect {
         maskEnabled: true
         maskSpreadAtMax: 1


### PR DESCRIPTION
work around ".live" is not available due to component versioning error

refs: https://github.com/luisbocanegra/plasma-panel-colorizer/issues/232