### PR TITLE
fix!: require allowing floating applets changes 6.4.0 and later 

### DIFF
--- a/package/contents/ui/code/globals.js
+++ b/package/contents/ui/code/globals.js
@@ -304,6 +304,7 @@ const defaultConfig = {
       shadow: true,
     },
     floatingDialogs: false,
+    floatingDialogsAllowOverride: false,
   },
   stockPanelSettings: baseStockPanelSettings,
   configurationOverrides: {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -54,6 +54,7 @@ PlasmoidItem {
     property bool hideWidget: plasmoid.configuration.hideWidget
     property bool fixedSidePaddingEnabled: isEnabled && panelBgItem.cfg.padding.enabled
     property bool floatingDialogs: main.isEnabled ? cfg.nativePanel.floatingDialogs : false
+    property bool floatingDialogsAllowOverride: main.isEnabled ? cfg.nativePanel.floatingDialogsAllowOverride : false
     property bool isEnabled: plasmoid.configuration.isEnabled
     property bool nativePanelBackgroundEnabled: (isEnabled ? cfg.nativePanel.background.enabled : true) || doPanelClickFix
     property real nativePanelBackgroundOpacity: isEnabled ? cfg.nativePanel.background.opacity : 1.0
@@ -1473,10 +1474,19 @@ PlasmoidItem {
         setFloatigApplets();
     }
 
+    onFloatingDialogsAllowOverrideChanged: {
+        setFloatigApplets();
+    }
+
     // inspired by https://invent.kde.org/plasma/plasma-desktop/-/merge_requests/1912
     function setFloatigApplets() {
         if (!containmentItem)
             return;
+        // Plasma 6.4 now has a floating applets option, but we are overriding it,
+        // so let's require the user to enable it before forcing one state of the other
+        if (main.plasmaVersion.isGreaterThan("6.3.5") && !floatingDialogsAllowOverride) {
+            return;
+        }
         if (floatingDialogs) {
             containmentItem.Plasmoid.containmentDisplayHints |= PlasmaCore.Types.ContainmentPrefersFloatingApplets;
         } else {

--- a/package/contents/ui/presets/Black Color Lines/settings.json
+++ b/package/contents/ui/presets/Black Color Lines/settings.json
@@ -668,7 +668,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }

--- a/package/contents/ui/presets/Black Gray Lines/settings.json
+++ b/package/contents/ui/presets/Black Gray Lines/settings.json
@@ -668,7 +668,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }

--- a/package/contents/ui/presets/Black/settings.json
+++ b/package/contents/ui/presets/Black/settings.json
@@ -667,7 +667,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }

--- a/package/contents/ui/presets/Bliss Light/settings.json
+++ b/package/contents/ui/presets/Bliss Light/settings.json
@@ -918,7 +918,8 @@
                 "opacity": 0,
                 "shadow": false
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/Bliss/settings.json
+++ b/package/contents/ui/presets/Bliss/settings.json
@@ -918,7 +918,8 @@
                 "opacity": 0,
                 "shadow": false
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/Blur Widgets 2/settings.json
+++ b/package/contents/ui/presets/Blur Widgets 2/settings.json
@@ -933,7 +933,8 @@
                 "opacity": 0,
                 "shadow": false
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/Blur Widgets/settings.json
+++ b/package/contents/ui/presets/Blur Widgets/settings.json
@@ -918,7 +918,8 @@
                 "opacity": 0,
                 "shadow": false
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/Carbon/settings.json
+++ b/package/contents/ui/presets/Carbon/settings.json
@@ -668,7 +668,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/ChromeOS/settings.json
+++ b/package/contents/ui/presets/ChromeOS/settings.json
@@ -918,7 +918,8 @@
                 "opacity": 0,
                 "shadow": true
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/Default/settings.json
+++ b/package/contents/ui/presets/Default/settings.json
@@ -667,7 +667,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }

--- a/package/contents/ui/presets/Dock/settings.json
+++ b/package/contents/ui/presets/Dock/settings.json
@@ -918,7 +918,8 @@
                 "opacity": 0,
                 "shadow": false
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }

--- a/package/contents/ui/presets/Eclipse/settings.json
+++ b/package/contents/ui/presets/Eclipse/settings.json
@@ -668,7 +668,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/Fake Floating/settings.json
+++ b/package/contents/ui/presets/Fake Floating/settings.json
@@ -918,7 +918,8 @@
                 "opacity": 0,
                 "shadow": false
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/Fusion 2/settings.json
+++ b/package/contents/ui/presets/Fusion 2/settings.json
@@ -668,7 +668,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/Fusion 3/settings.json
+++ b/package/contents/ui/presets/Fusion 3/settings.json
@@ -918,7 +918,8 @@
                 "opacity": 0,
                 "shadow": false
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/Fusion/settings.json
+++ b/package/contents/ui/presets/Fusion/settings.json
@@ -654,7 +654,8 @@
                 "opacity": 0,
                 "shadow": true
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }

--- a/package/contents/ui/presets/Neon Lights/settings.json
+++ b/package/contents/ui/presets/Neon Lights/settings.json
@@ -641,7 +641,8 @@
                 "opacity": 0,
                 "shadow": true
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }

--- a/package/contents/ui/presets/OG/settings.json
+++ b/package/contents/ui/presets/OG/settings.json
@@ -667,7 +667,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }

--- a/package/contents/ui/presets/Orbit/settings.json
+++ b/package/contents/ui/presets/Orbit/settings.json
@@ -933,7 +933,8 @@
                 "opacity": 0,
                 "shadow": false
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/Outline Accent/settings.json
+++ b/package/contents/ui/presets/Outline Accent/settings.json
@@ -668,7 +668,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/Outline Colors/settings.json
+++ b/package/contents/ui/presets/Outline Colors/settings.json
@@ -668,7 +668,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }

--- a/package/contents/ui/presets/Outline/settings.json
+++ b/package/contents/ui/presets/Outline/settings.json
@@ -668,7 +668,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/Pulse/settings.json
+++ b/package/contents/ui/presets/Pulse/settings.json
@@ -668,7 +668,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/Rounded Widgets Floating/settings.json
+++ b/package/contents/ui/presets/Rounded Widgets Floating/settings.json
@@ -641,7 +641,8 @@
                 "opacity": 0,
                 "shadow": true
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }

--- a/package/contents/ui/presets/Rounded Widgets/settings.json
+++ b/package/contents/ui/presets/Rounded Widgets/settings.json
@@ -641,7 +641,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }

--- a/package/contents/ui/presets/Rubik/settings.json
+++ b/package/contents/ui/presets/Rubik/settings.json
@@ -668,7 +668,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }

--- a/package/contents/ui/presets/Skeuomorphic 2/settings.json
+++ b/package/contents/ui/presets/Skeuomorphic 2/settings.json
@@ -668,7 +668,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/Skeuomorphic white/settings.json
+++ b/package/contents/ui/presets/Skeuomorphic white/settings.json
@@ -641,7 +641,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }

--- a/package/contents/ui/presets/Skittles/settings.json
+++ b/package/contents/ui/presets/Skittles/settings.json
@@ -668,7 +668,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }

--- a/package/contents/ui/presets/Sky/settings.json
+++ b/package/contents/ui/presets/Sky/settings.json
@@ -668,7 +668,8 @@
                 "opacity": 0,
                 "shadow": true
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }

--- a/package/contents/ui/presets/Sleek/settings.json
+++ b/package/contents/ui/presets/Sleek/settings.json
@@ -933,7 +933,8 @@
                 "opacity": 0,
                 "shadow": true
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/Solid/settings.json
+++ b/package/contents/ui/presets/Solid/settings.json
@@ -641,7 +641,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }

--- a/package/contents/ui/presets/Translucent/settings.json
+++ b/package/contents/ui/presets/Translucent/settings.json
@@ -653,7 +653,8 @@
                 "opacity": 0,
                 "shadow": true
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/Transparent/settings.json
+++ b/package/contents/ui/presets/Transparent/settings.json
@@ -918,7 +918,8 @@
                 "opacity": 0,
                 "shadow": true
             },
-            "floatingDialogs": true
+            "floatingDialogs": true,
+            "floatingDialogsAllowOverride": true
         }
     }
 }

--- a/package/contents/ui/presets/White/settings.json
+++ b/package/contents/ui/presets/White/settings.json
@@ -668,7 +668,8 @@
                 "opacity": 1,
                 "shadow": true
             },
-            "floatingDialogs": false
+            "floatingDialogs": false,
+            "floatingDialogsAllowOverride": false
         }
     }
 }


### PR DESCRIPTION
Since version 6.4.0, Plasma now has a built-in Floating panel and applets option, we are overriding it since older versions blocking the user from changing it manually.

Now the user has to explicitly allow changing it so we don't alter it by default

refs: https://github.com/luisbocanegra/plasma-panel-colorizer/issues/293

BREAKING CHANGE: If you are forcing floating dialogs (applets) you will need to update your settings/presets to allow floating applets changes in plasma 6.4.0 and later **Appearance** > **Floating applets** > enable (check) allow changes