### PR TITLE
Allow localization of some strings.

### DIFF
--- a/package/contents/ui/components/FormWidgetSettings.qml
+++ b/package/contents/ui/components/FormWidgetSettings.qml
@@ -359,25 +359,25 @@ ColumnLayout {
         actions: [
             Kirigami.Action {
                 icon.name: "color-picker"
-                text: "Color"
+                text: i18n("Color")
                 checked: currentTab === 0
                 onTriggered: currentTab = 0
             },
             Kirigami.Action {
                 icon.name: "rectangle-shape-symbolic"
-                text: "Shape"
+                text: i18n("Shape")
                 checked: currentTab === 1
                 onTriggered: currentTab = 1
             },
             Kirigami.Action {
                 icon.name: "bordertool-symbolic"
-                text: "Border"
+                text: i18n("Border")
                 checked: currentTab === 2
                 onTriggered: currentTab = 2
             },
             Kirigami.Action {
                 icon.name: "kstars_horizon-symbolic"
-                text: "Shadow"
+                text: i18n("Shadow")
                 checked: currentTab === 3
                 onTriggered: currentTab = 3
             }

--- a/package/contents/ui/components/Header.qml
+++ b/package/contents/ui/components/Header.qml
@@ -78,19 +78,19 @@ ColumnLayout {
             x: linksButton.x
 
             Action {
-                text: "Changelog"
+                text: i18n("Changelog")
                 onTriggered: Qt.openUrlExternally("https://github.com/luisbocanegra/plasma-panel-colorizer/blob/main/CHANGELOG.md")
                 icon.name: "view-calendar-list-symbolic"
             }
 
             Action {
-                text: "Releases"
+                text: i18n("Releases")
                 onTriggered: Qt.openUrlExternally("https://github.com/luisbocanegra/plasma-panel-colorizer/releases")
                 icon.name: "update-none-symbolic"
             }
 
             Action {
-                text: "Matrix chat"
+                text: i18n("Matrix chat")
                 icon.name: Qt.resolvedUrl("../../icons/matrix_logo.svg").toString().replace("file://", "")
                 onTriggered: Qt.openUrlExternally("https://matrix.to/#/#kde-plasma-panel-colorizer:matrix.org")
             }
@@ -98,7 +98,7 @@ ColumnLayout {
             MenuSeparator {}
 
             Menu {
-                title: "Home page"
+                title: i18n("Home page")
                 icon.name: "globe"
 
                 Action {
@@ -107,47 +107,47 @@ ColumnLayout {
                 }
 
                 Action {
-                    text: "KDE Store"
+                    text: i18n("KDE Store")
                     onTriggered: Qt.openUrlExternally("https://store.kde.org/p/2130967")
                 }
             }
 
             Menu {
-                title: "Issues"
+                title: i18n("Issues")
                 icon.name: "project-open-symbolic"
 
                 Action {
-                    text: "Current issues"
+                    text: i18n("Current issues")
                     onTriggered: Qt.openUrlExternally("https://github.com/luisbocanegra/plasma-panel-colorizer/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen")
                 }
 
                 Action {
-                    text: "Report a bug"
+                    text: i18n("Report a bug")
                     onTriggered: Qt.openUrlExternally("https://github.com/luisbocanegra/plasma-panel-colorizer/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title=%5BBug%5D%3A+")
                 }
 
                 Action {
-                    text: "Request a feature"
+                    text: i18n("Request a feature")
                     onTriggered: Qt.openUrlExternally("https://github.com/luisbocanegra/plasma-panel-colorizer/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.md&title=%5BFeature+Request%5D%3A+")
                 }
             }
 
             Menu {
-                title: "Help"
+                title: i18n("Help")
                 icon.name: "question-symbolic"
 
                 Action {
-                    text: "FAQ"
+                    text: i18n("FAQ")
                     onTriggered: Qt.openUrlExternally("https://github.com/luisbocanegra/plasma-panel-colorizer?tab=readme-ov-file#faq")
                 }
 
                 Action {
-                    text: "Discussions"
+                    text: i18n("Discussions")
                     onTriggered: Qt.openUrlExternally("https://github.com/luisbocanegra/plasma-panel-colorizer/discussions")
                 }
 
                 Action {
-                    text: "Send an email"
+                    text: i18n("Send an email")
                     onTriggered: Qt.openUrlExternally("mailto:luisbocanegra17b@gmail.com")
                 }
             }
@@ -155,11 +155,11 @@ ColumnLayout {
             MenuSeparator {}
 
             Menu {
-                title: "Donate"
+                title: i18n("Donate")
                 icon.name: "love"
 
                 Action {
-                    text: "GitHub sponsors"
+                    text: i18n("GitHub sponsors")
                     onTriggered: Qt.openUrlExternally("https://github.com/sponsors/luisbocanegra")
                 }
 
@@ -175,7 +175,7 @@ ColumnLayout {
             }
 
             Action {
-                text: "My other projects"
+                text: i18n("My other projects")
                 onTriggered: Qt.openUrlExternally("https://github.com/luisbocanegra?tab=repositories&type=source")
                 icon.name: "starred"
             }

--- a/package/contents/ui/configPresetAutoload.qml
+++ b/package/contents/ui/configPresetAutoload.qml
@@ -25,7 +25,7 @@ KCM.SimpleKCM {
     property var autoLoadConfig: JSON.parse(cfg_presetAutoloading)
 
     property alias cfg_widgetClickMode: widgetClickModeCombo.currentIndex
-    readonly property list<string> widgetClickModes: ["Toggle Panel Colorizer", "Switch presets", "Show popup"]
+    readonly property list<string> widgetClickModes: [i18n("Toggle Panel Colorizer"), i18n("Switch presets"), i18n("Show popup")]
 
     property string cfg_switchPresets
     property var switchPresets: JSON.parse(cfg_switchPresets)
@@ -327,7 +327,7 @@ KCM.SimpleKCM {
 
             ComboBox {
                 id: widgetClickModeCombo
-                Kirigami.FormData.label: "Action:"
+                Kirigami.FormData.label: i18n("Action:")
                 model: widgetClickModes
             }
 


### PR DESCRIPTION
As stated in #366 , some strings couldn't be translated.

This should allow it.

I am not sure whether this line will work:
`readonly property list<string> widgetClickModes: [i18n("Toggle Panel Colorizer"), i18n("Switch presets"), i18n("Show popup")]`