### PR TITLE
fix: system tray wiget matching not working with regular plasma widgets

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -323,7 +323,7 @@ PlasmoidItem {
                     "busy": false
                 };
             } else {
-                return Utils.getWidgetProperties(target, PlasmaCore.Types, hovered, main.plasmaVersion);
+                return Utils.getWidgetProperties(target, PlasmaCore.Types, hovered, main.plasmaVersion, inTray);
             }
         }
         property string widgetName: widgetProperties.name


### PR DESCRIPTION
BREAKING CHANGE: If using color fix or overrides for individual system tray widgets, they will need to be reconfigured manually after this update. App tray icons, (e.g Spotify) or widgets outside the system tray are not affected by this change.

refs: https://github.com/luisbocanegra/plasma-panel-colorizer/issues/358