### PR TITLE
feat: system tray application status (StatusNotifier) icons replacement

### DIFF
--- a/package/contents/config/config.qml
+++ b/package/contents/config/config.qml
@@ -57,6 +57,12 @@ ConfigModel {
     }
 
     ConfigCategory {
+        name: i18n("System Tray Icons Replacer")
+        icon: "document-replace-symbolic"
+        source: "configTrayIconsReplacer.qml"
+    }
+
+    ConfigCategory {
         name: i18n("General")
         icon: "configure-symbolic"
         source: "configGeneral.qml"

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -107,5 +107,25 @@
         type="String">
         <default>{"widgets":[]}</default>
     </entry>
+    <entry
+        name="systemTrayIconsReplacementEnabled"
+        type="Bool">
+        <default>false</default>
+    </entry>
+    <entry
+        name="systemTrayIconUserReplacements"
+        type="String">
+        <default></default>
+    </entry>
+    <entry
+        name="logSystemTrayIconChanges"
+        type="Bool">
+        <default>false</default>
+    </entry>
+    <entry
+        name="systemTrayIconBuiltinReplacementsEnabled"
+        type="Bool">
+        <default>true</default>
+    </entry>
   </group>
 </kcfg>

--- a/package/contents/ui/TrayIconReplacementsModel.qml
+++ b/package/contents/ui/TrayIconReplacementsModel.qml
@@ -1,0 +1,115 @@
+pragma ComponentBehavior: Bound
+import QtQuick
+
+Item {
+    id: root
+    property ListModel model: ListModel {}
+    property bool isLoading: true
+
+    signal updated
+
+    function initModel(configString) {
+        model.clear();
+        let items = [];
+
+        try {
+            items = JSON.parse(configString);
+            console.log(JSON.stringify(items));
+        } catch (e) {
+            console.error(e.message, "\n", e.stack);
+        }
+
+        for (let item of items) {
+            model.append(item);
+        }
+        root.isLoading = false;
+    }
+
+    function addItem(hash) {
+        model.append({
+            "description": "",
+            "hash": hash ?? "",
+            "icon": "",
+            "enabled": true
+        });
+        updated();
+    }
+
+    function appendRule(rule) {
+        model.append(rule);
+        updated();
+    }
+
+    function insertRule(index, rule) {
+        model.insert(index, rule);
+        updated();
+    }
+
+    function clear() {
+        model.clear();
+        updated();
+    }
+
+    function removeItem(index) {
+        model.remove(index, 1);
+        updated();
+    }
+
+    function updateItem(index, property, value) {
+        model.setProperty(index, property, value);
+        updated();
+    }
+
+    function moveItem(oldIndex, newIndex) {
+        model.move(oldIndex, newIndex, 1);
+        updated();
+    }
+
+    function hashExists(hash) {
+        let exists = false;
+
+        for (let i = 0; i < model.count; i++) {
+            const item = model.get(i);
+            if (item.hash === hash) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function disableAll() {
+        for (let i = 0; i < model.count; i++) {
+            const item = model.get(i);
+            item.enabled = false;
+        }
+        updated();
+    }
+
+    function enableAll() {
+        for (let i = 0; i < model.count; i++) {
+            const item = model.get(i);
+            item.enabled = true;
+        }
+        updated();
+    }
+
+    function toggleAll() {
+        for (let i = 0; i < model.count; i++) {
+            const item = model.get(i);
+            item.enabled = !item.enabled;
+        }
+        updated();
+    }
+
+    function disableAllOthers(index) {
+        for (let i = 0; i < model.count; i++) {
+            const item = model.get(i);
+            if (i === index) {
+                item.enabled = true;
+            } else {
+                item.enabled = false;
+            }
+        }
+        updated();
+    }
+}

--- a/package/contents/ui/code/globals.js
+++ b/package/contents/ui/code/globals.js
@@ -14,17 +14,17 @@ const baseGradientList = [
   { color: "#21fd00", position: 0.5 },
   { color: "#0e1eff", position: 0.75 },
   { color: "#fd12ff", position: 1 }
-]
+];
 
 const baseGradientConfig = {
   stops: baseGradientList,
   orientation: 0
-}
+};
 
 const baseImageConfig = {
   source: "",
   fillMode: 2
-}
+};
 
 const baseAnimation = {
   enabled: false,
@@ -226,7 +226,7 @@ const baseOverride = {
   borderSecondary: baseBorder,
   shadow: baseShadowConfig,
   enabled: true,
-}
+};
 
 const baseOverrideConfig = {
   disabledFallback: true,
@@ -337,7 +337,11 @@ const ignoredConfigs = [
   "editModeGridSettings",
   "pluginFound",
   "configureFromAllWidgets",
-  "hiddenWidgets"
+  "hiddenWidgets",
+  "systemTrayIconsReplacementEnabled",
+  "systemTrayIconUserReplacements",
+  "systemTrayIconBuiltinReplacementsEnabled",
+  "logSystemTrayIconChanges"
 ];
 
 const editModeGridSettings = {

--- a/package/contents/ui/code/statusNotifierItemIconHashes.js
+++ b/package/contents/ui/code/statusNotifierItemIconHashes.js
@@ -1,0 +1,195 @@
+const hashes = [
+  {
+    "description": "Discord",
+    "hash": "8329bc25398ce60c34861ae1410316ba1d233371",
+    "icon": "discord-tray",
+    "enabled": true
+  },
+  {
+    "description": "Discord (unread)",
+    "hash": "a7d1e477d6bb2b6efc4edd96eb19f4c1a83c34eb",
+    "icon": "discord-tray-unread",
+    "enabled": true
+  },
+  {
+    "description": "fooyin",
+    "hash": "78e35a2398151e346da2990e4d6d4ebba35d4758",
+    "icon": "",
+    "enabled": true
+  },
+  {
+    "description": "Element",
+    "hash": "eb02846a6e6000b6bdb55e5840ae47f5d4dc2bfb",
+    "icon": "element-desktop-tray",
+    "enabled": true
+  },
+  {
+    "description": "Element (1 unread)",
+    "hash": "09370ab19db7c74b1031d43a7e73a6c31f7918f6",
+    "icon": "",
+    "enabled": true
+  },
+  {
+    "description": "Element (2 unread)",
+    "hash": "5252f3250cec8b8b764aaeadd63e3b916270e5a2",
+    "icon": "",
+    "enabled": true
+  },
+  {
+    "description": "GPU Screen Recorder",
+    "hash": "fcc6f97b0e027399a57a7a0c856eca860d4eae91",
+    "icon": "simplescreenrecorder-panel",
+    "enabled": true
+  },
+  {
+    "description": "GPU Screen Recorder (recording)",
+    "hash": "6f1fe912b983467f314a769331855efc5a7ba830",
+    "icon": "simplescreenrecorder-recording",
+    "enabled": true
+  },
+  {
+    "description": "GPU Screen Recorder (paused)",
+    "hash": "5426ee8b99cd67148f33a3f656bfa6cb0d74f5f9",
+    "icon": "simplescreenrecorder-paused",
+    "enabled": true
+  },
+  {
+    "description": "Bitwarden",
+    "hash": "b57b039f23f9b230f3e55eb112470cc51ab97da7",
+    "icon": "bitwarden-tray",
+    "enabled": true
+  },
+  {
+    "description": "Signal",
+    "hash": "7b2020f2b27728eb56437cb72b20a35319e3da1a",
+    "icon": "signal-tray",
+    "enabled": true
+  },
+  {
+    "description": "virt-manager (replaces virt-manager icon from papirus)",
+    "hash": "c0b947cdceed56983ec965f63d6d330e3af476f2",
+    "icon": "virt-manager-panel",
+    "enabled": true
+  },
+  {
+    "description": "Obsidian (obsidian-tray add-on)",
+    "hash": "939b767c420bf752aee3d0f4c9f41b982678526a",
+    "icon": "",
+    "enabled": true
+  },
+  {
+    "description": "super productivity (launched)",
+    "hash": "7b67348b06aa7bcd0ebb2fcd73f79079a7b7f13a",
+    "icon": "superproductivity-tray-run",
+    "enabled": true
+  },
+  {
+    "description": "super productivity (done)",
+    "hash": "700ecd6bb3e811579e7f18d9e1dc742ad40e6680",
+    "icon": "superproductivity-tray",
+    "enabled": true
+  },
+  {
+    "description": "super productivity 0 (start)",
+    "hash": "d1e1350004aafa4e27d850f19d1572ddf77f40a3",
+    "icon": "superproductivity-tray-0",
+    "enabled": true
+  },
+  {
+    "description": "super productivity 1",
+    "hash": "c29b7bfc1fda1e523964cc89054145ccc6126cea",
+    "icon": "superproductivity-tray-1",
+    "enabled": true
+  },
+  {
+    "description": "super productivity 2",
+    "hash": "71ea166e4a19602adc70aa20dc6ce8f12589bb07",
+    "icon": "superproductivity-tray-2",
+    "enabled": true
+  },
+  {
+    "description": "super productivity 3",
+    "hash": "3352f642ef7687849eb73ea1ff57d9e438f82b77",
+    "icon": "superproductivity-tray-3",
+    "enabled": true
+  },
+  {
+    "description": "super productivity 4",
+    "hash": "e42e1cac870b24fb22812b1021600022f337c2f2",
+    "icon": "superproductivity-tray-4",
+    "enabled": true
+  },
+  {
+    "description": "super productivity 5",
+    "hash": "c1de0f6042e2a969b4138f7e23ebdc8d074c9e2f",
+    "icon": "superproductivity-tray-5",
+    "enabled": true
+  },
+  {
+    "description": "super productivity 6",
+    "hash": "4fd04c5ec8acb66f86b6947af94ba9b281a11d0a",
+    "icon": "superproductivity-tray-6",
+    "enabled": true
+  },
+  {
+    "description": "super productivity 7",
+    "hash": "4fd04c5ec8acb66f86b6947af94ba9b281a11d0a",
+    "icon": "superproductivity-tray-7",
+    "enabled": true
+  },
+  {
+    "description": "super productivity 8",
+    "hash": "326e2f3af2cd7633ebca9fb494778ab435ce93d7",
+    "icon": "superproductivity-tray-8",
+    "enabled": true
+  },
+  {
+    "description": "super productivity 9",
+    "hash": "bf9d328dffda92f1430f016257ad2461ba97fa50",
+    "icon": "superproductivity-tray-9",
+    "enabled": true
+  },
+  {
+    "description": "super productivity 10",
+    "hash": "3d8ea90331d50381230afd83327662d08464e2ae",
+    "icon": "superproductivity-tray-10",
+    "enabled": true
+  },
+  {
+    "description": "super productivity 11",
+    "hash": "cd27cdf64249d9731d4bf89a9bce30f382486079",
+    "icon": "superproductivity-tray-11",
+    "enabled": true
+  },
+  {
+    "description": "super productivity 12",
+    "hash": "3595f4c7e2b265d7a423d9eae0e5e46967d67c6d",
+    "icon": "superproductivity-tray-12",
+    "enabled": true
+  },
+  {
+    "description": "super productivity 13",
+    "hash": "bc403941f7f6f13229664550a1c923abc97441e5",
+    "icon": "superproductivity-tray-13",
+    "enabled": true
+  },
+  {
+    "description": "super productivity 14",
+    "hash": "0df597305998fb18ffcc5455a6f35804d5f463ff",
+    "icon": "superproductivity-tray-14",
+    "enabled": true
+  },
+  {
+    "description": "super productivity 15 (full)",
+    "hash": "e84369d6d3d49029877d4af677663da104486f80",
+    "icon": "superproductivity-tray-15",
+    "enabled": true
+  },
+  {
+    "description": "LocalSend",
+    "hash": "1ecd2bf8b9dbe96adfda270e771c8aa914aa6b32",
+    "icon": "",
+    "enabled": true
+  }
+]
+

--- a/package/contents/ui/components/Header.qml
+++ b/package/contents/ui/components/Header.qml
@@ -28,16 +28,6 @@ ColumnLayout {
 
             CheckBox {
                 id: isEnabledCheckbox
-
-                Kirigami.Theme.inherit: false
-                text: checked ? "" : i18n("Disabled")
-
-                Binding {
-                    target: isEnabledCheckbox
-                    property: "Kirigami.Theme.textColor"
-                    value: Kirigami.Theme.neutralTextColor
-                    when: !isEnabledCheckbox.checked
-                }
             }
         }
 

--- a/package/contents/ui/components/SettingImportExport.qml
+++ b/package/contents/ui/components/SettingImportExport.qml
@@ -29,7 +29,9 @@ RowLayout {
     }
 
     Kirigami.ContextualHelpButton {
+        flat: false
         toolTipText: i18n("Export these settings to the default configuration folder and import them in other instances of Panel Colorizer")
+        Layout.fillHeight: true
     }
 
     Kirigami.PromptDialog {

--- a/package/contents/ui/configTrayIconsReplacer.qml
+++ b/package/contents/ui/configTrayIconsReplacer.qml
@@ -1,0 +1,400 @@
+pragma ComponentBehavior: Bound
+import QtCore
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.kde.iconthemes as KIconThemes
+import org.kde.kcmutils as KCM
+import org.kde.kirigami as Kirigami
+import org.kde.plasma.plasmoid
+import "components" as Components
+import "code/statusNotifierItemIconHashes.js" as SNIIconHashes
+
+KCM.ScrollViewKCM {
+    id: root
+    padding: 0
+    headerPaddingEnabled: false
+    implicitWidth: Kirigami.Units.gridUnit * 15
+    implicitHeight: Kirigami.Units.gridUnit * 30
+    property alias cfg_systemTrayIconsReplacementEnabled: systemTrayIconsReplacementEnabled.checked
+    property string cfg_systemTrayIconUserReplacements
+    property alias cfg_systemTrayIconBuiltinReplacementsEnabled: systemTrayIconBuiltinReplacementsEnabled.checked
+    property alias cfg_logSystemTrayIconChanges: logSystemTrayIconChanges.checked
+    property bool isLoading: trayIconReplacementsModel.isLoading
+    property alias cfg_isEnabled: headerComponent.isEnabled
+    property var panelColorizer: null
+
+    property string configDir: StandardPaths.writableLocation(StandardPaths.HomeLocation).toString().substring(7) + "/.config/panel-colorizer/"
+    property string importCmd: "cat '" + configDir + "trayIconReplacements.json'"
+    property string crateConfigDirCmd: "mkdir -p " + configDir
+
+    readonly property Kirigami.Action addContextMenuAction: Kirigami.Action {
+        icon.name: "list-add-symbolic"
+        text: i18n("Add new")
+        onTriggered: trayIconReplacementsModel.addItem()
+    }
+    readonly property Kirigami.Action restoreDefaultAction: Kirigami.Action {
+        icon.name: "edit-delete-symbolic"
+        text: i18n("Remove all")
+        onTriggered: trayIconReplacementsModel.clear()
+    }
+
+    function updateConfig() {
+        let actions = new Array();
+        for (let i = 0; i < trayIconReplacementsModel.model.count; i++) {
+            let item = trayIconReplacementsModel.model.get(i);
+            actions.push({
+                "description": item.description,
+                "hash": item.hash,
+                "icon": item.icon,
+                "enabled": item.enabled
+            });
+        }
+        cfg_systemTrayIconUserReplacements = JSON.stringify(actions);
+    }
+
+    TrayIconReplacementsModel {
+        id: trayIconReplacementsModel
+        onUpdated: () => {
+            root.updateConfig();
+        }
+    }
+
+    TrayIconReplacementsModel {
+        id: trayIconBuiltinReplacementsModel
+    }
+
+    Component.onCompleted: {
+        trayIconReplacementsModel.initModel(cfg_systemTrayIconUserReplacements);
+        trayIconBuiltinReplacementsModel.initModel(JSON.stringify(SNIIconHashes.hashes));
+        try {
+            panelColorizer = Qt.createQmlObject("import org.kde.plasma.panelcolorizer 1.0; PanelColorizer { id: panelColorizer }", root);
+        } catch (e) {
+            console.warn("QML Plugin org.kde.plasma.panelcolorizer not found.");
+        }
+    }
+
+    RunCommand {
+        id: runCommand
+    }
+
+    Connections {
+        function onExited(cmd, exitCode, exitStatus, stdout, stderr) {
+            if (exitCode !== 0)
+                return;
+
+            if (cmd.startsWith("cat")) {
+                const content = stdout.trim();
+                try {
+                    console.log(content);
+                    trayIconReplacementsModel.initModel(content);
+                } catch (e) {
+                    console.error(e);
+                }
+            }
+        }
+
+        target: runCommand
+    }
+
+    header: ColumnLayout {
+        spacing: 0
+        Components.Header {
+            id: headerComponent
+        }
+        Kirigami.Separator {
+            Layout.fillWidth: true
+        }
+        Kirigami.InlineMessage {
+            Layout.fillWidth: true
+            text: i18n("Replace System Tray icons with icons from the current icon theme or a local file. The built-in rules icons are part of <a href=\"https://github.com/PapirusDevelopmentTeam/papirus-icon-theme\">Papirus icon theme</a>.")
+            visible: true
+            type: Kirigami.MessageType.Information
+            spacing: 0
+            Layout.margins: Kirigami.Units.mediumSpacing
+        }
+        Kirigami.InlineMessage {
+            Layout.fillWidth: true
+            text: i18n("C++ plugin not found, this feature will not work. Install the plugin and reboot or restart plasmashell to be able to use it <a href=\"https://github.com/luisbocanegra/plasma-panel-colorizer?tab=readme-ov-file#manually\">Install instructions</a>.")
+            visible: root.panelColorizer === null
+            type: Kirigami.MessageType.Error
+            spacing: 0
+            Layout.margins: Kirigami.Units.mediumSpacing
+        }
+        Kirigami.InlineMessage {
+            Layout.fillWidth: true
+            text: i18n("The installed version of the C++ plugin doesn't support this feature, update the plugin and reboot or restart plasmashell to be able to use it <a href=\"https://github.com/luisbocanegra/plasma-panel-colorizer?tab=readme-ov-file#manually\">Install instructions</a>.")
+            visible: root.panelColorizer && (typeof root.panelColorizer?.getIconHash !== "function")
+            type: Kirigami.MessageType.Error
+            spacing: 0
+            Layout.margins: Kirigami.Units.mediumSpacing
+        }
+        Kirigami.FormLayout {
+            enabled: root.cfg_isEnabled
+            RowLayout {
+                Kirigami.FormData.label: i18n("Enable")
+                CheckBox {
+                    id: systemTrayIconsReplacementEnabled
+                }
+            }
+            RowLayout {
+                Kirigami.FormData.label: i18n("Log icon changes:")
+                CheckBox {
+                    id: logSystemTrayIconChanges
+                }
+                Kirigami.ContextualHelpButton {
+                    toolTipText: i18n("Icon hashes will be printed to the system log")
+                }
+            }
+            RowLayout {
+                enabled: root.cfg_systemTrayIconsReplacementEnabled
+                Kirigami.FormData.label: i18n("Enable built-in rules:")
+                CheckBox {
+                    id: systemTrayIconBuiltinReplacementsEnabled
+                }
+                ToolButton {
+                    id: showBuiltInRules
+                    text: i18n("Show")
+                    checkable: true
+                }
+            }
+        }
+
+        ToolButton {
+            id: showHowToLabel
+            text: i18n("How to use")
+            checkable: true
+            Layout.alignment: Qt.AlignHCenter
+            Layout.margins: Kirigami.Units.mediumSpacing
+        }
+        Label {
+            text: "1. Enable <b>Log icon changes</b> above<br>2. Run <b>journalctl -f</b> from terminal<br>3. Hover the System tray entry or trigger an icon change<br>4. Copy the icon <b>SHA1</b> (long string of numbers and letters)<br>5. Add a new rule with the <b>SHA1</b> and your icon name or icon file"
+            wrapMode: Label.WordWrap
+            font.features: {
+                "tnum": 1
+            }
+            visible: showHowToLabel.checked
+            Layout.margins: Kirigami.Units.mediumSpacing
+            Layout.fillWidth: true
+        }
+        Label {
+            text: "<b>Note</b>: There are some rules without icon as there was no matching one in Papirus, you can override those with your own icons by adding the SHA1 to <b>User Replacements</b>"
+            wrapMode: Label.WordWrap
+            font.features: {
+                "tnum": 1
+            }
+            visible: showHowToLabel.checked
+            Layout.margins: Kirigami.Units.mediumSpacing
+            Layout.fillWidth: true
+        }
+        Label {
+            text: "<b>Note</b>: Some applications like Signal are missing accumulated notification icons, contribution of missing icons via GitHub pull request or issue is very welcome, please do so by providing the the description + sha1 + icon-name from Papirus (panel/status icons only if no matching icon exists, otherwise it can be omitted)</b>"
+            wrapMode: Label.WordWrap
+            font.features: {
+                "tnum": 1
+            }
+            visible: showHowToLabel.checked
+            Layout.margins: Kirigami.Units.mediumSpacing
+            Layout.fillWidth: true
+        }
+        Components.SettingImportExport {
+            onExportConfirmed: {
+                runCommand.run(root.crateConfigDirCmd);
+                runCommand.run("echo '" + root.cfg_systemTrayIconUserReplacements + "' > '" + root.configDir + "trayIconReplacements.json'");
+            }
+            onImportConfirmed: runCommand.run(root.importCmd)
+            Layout.margins: Kirigami.Units.mediumSpacing
+            enabled: root.cfg_isEnabled && root.cfg_systemTrayIconsReplacementEnabled
+        }
+    }
+    view: ListView {
+        id: list
+        enabled: root.cfg_isEnabled && root.cfg_systemTrayIconsReplacementEnabled
+        model: showBuiltInRules.checked ? trayIconBuiltinReplacementsModel.model : trayIconReplacementsModel.model
+        headerPositioning: ListView.OverlayHeader
+        header: Kirigami.InlineViewHeader {
+            width: list.width
+            text: showBuiltInRules.checked ? i18n("Built-in Rules (read only)") : i18n("User Rules")
+            actions: {
+                if (showBuiltInRules.checked) {
+                    return [];
+                }
+                return [root.restoreDefaultAction, root.addContextMenuAction];
+            }
+        }
+        delegate: Item {
+            id: itemDelegate
+            readonly property var view: ListView.view
+            required property string hash
+            required property string icon
+            required property string description
+            required property bool enabled
+            required property int index
+            implicitWidth: ListView.view.width
+            implicitHeight: delegate.height
+            ItemDelegate {
+                id: delegate
+                implicitWidth: itemDelegate.implicitWidth
+                // There's no need for a list item to ever be selected
+                down: false
+                highlighted: false
+                contentItem: RowLayout {
+                    spacing: Kirigami.Units.smallSpacing
+                    Layout.fillWidth: true
+
+                    Kirigami.ListItemDragHandle {
+                        visible: itemDelegate.view.count > 1
+                        listItem: delegate
+                        listView: itemDelegate.view
+                        onMoveRequested: (oldIndex, newIndex) => {
+                            trayIconReplacementsModel.moveItem(oldIndex, newIndex, 1);
+                        }
+                        enabled: !showBuiltInRules.checked
+                    }
+
+                    ToolButton {
+                        icon.name: itemDelegate.enabled ? "checkmark-symbolic" : "dialog-close-symbolic"
+                        checkable: true
+                        checked: itemDelegate.enabled
+                        highlighted: itemDelegate.enabled
+                        onCheckedChanged: {
+                            if (root.isLoading || showBuiltInRules.checked)
+                                return;
+                            trayIconReplacementsModel.updateItem(itemDelegate.index, "enabled", checked);
+                        }
+                        Layout.fillHeight: true
+                        Layout.preferredWidth: height
+                        ToolTip.delay: 1000
+                        ToolTip.visible: hovered
+                        ToolTip.text: i18n("Whether or not this replacement is enabled")
+                        enabled: !showBuiltInRules.checked
+                    }
+
+                    TextField {
+                        text: itemDelegate.description
+                        placeholderText: i18n("Description (optional)")
+                        ToolTip.delay: 1000
+                        ToolTip.visible: hovered
+                        ToolTip.text: i18n("Description")
+                        onTextChanged: {
+                            if (root.isLoading || showBuiltInRules.checked)
+                                return;
+                            trayIconReplacementsModel.updateItem(itemDelegate.index, "description", text);
+                        }
+                        Layout.fillWidth: true
+                        enabled: itemDelegate.enabled
+                        readOnly: showBuiltInRules.checked
+                    }
+
+                    TextField {
+                        Layout.fillWidth: true
+                        text: itemDelegate.hash
+                        font.family: "monospace"
+                        color: Kirigami.Theme.textColor
+                        placeholderText: i18n("SHA1")
+                        ToolTip.delay: 1000
+                        ToolTip.visible: hovered
+                        ToolTip.text: i18n("Original icon SHA1")
+                        onTextChanged: {
+                            if (root.isLoading || showBuiltInRules.checked)
+                                return;
+                            trayIconReplacementsModel.updateItem(itemDelegate.index, "hash", text);
+                        }
+                        enabled: itemDelegate.enabled
+                        readOnly: showBuiltInRules.checked
+                    }
+
+                    TextField {
+                        text: itemDelegate.icon
+                        placeholderText: i18n("Custom icon")
+                        ToolTip.delay: 1000
+                        ToolTip.visible: hovered
+                        ToolTip.text: i18n("Icon name or file")
+                        onTextChanged: {
+                            if (root.isLoading || showBuiltInRules.checked)
+                                return;
+                            trayIconReplacementsModel.updateItem(itemDelegate.index, "icon", text);
+                        }
+                        Layout.preferredWidth: 300
+                        enabled: itemDelegate.enabled
+                        readOnly: showBuiltInRules.checked
+                    }
+
+                    Button {
+                        id: iconButton
+                        hoverEnabled: true
+                        ToolTip.delay: Kirigami.Units.toolTipDelay
+                        ToolTip.text: i18nc("@info:tooltip", "Icon name is \"%1\"", itemDelegate.icon)
+                        ToolTip.visible: iconButton.hovered && itemDelegate.icon.length > 0
+                        icon.name: itemDelegate.icon || "unknown"
+                        enabled: itemDelegate.enabled
+                        KIconThemes.IconDialog {
+                            id: iconDialog
+                            onIconNameChanged: {
+                                itemDelegate.icon = iconName;
+                            }
+                        }
+
+                        onPressed: {
+                            if (showBuiltInRules.checked) {
+                                return;
+                            }
+                            if (iconMenu.opened) {
+                                iconMenu.close();
+                            } else {
+                                iconMenu.open();
+                            }
+                        }
+
+                        Menu {
+                            id: iconMenu
+
+                            // Appear below the button
+                            y: parent.height
+
+                            MenuItem {
+                                text: i18nc("@item:inmenu Open icon chooser dialog", "Choose…")
+                                icon.name: "document-open-folder"
+                                onClicked: iconDialog.open()
+                            }
+                            MenuItem {
+                                text: i18nc("@action:inmenu", "Remove icon")
+                                icon.name: "delete"
+                                enabled: itemDelegate.icon !== ""
+                                onClicked: itemDelegate.icon = ""
+                            }
+                        }
+                    }
+
+                    Button {
+                        id: copyRuleButton
+                        icon.name: showBuiltInRules.checked ? "edit-copy-symbolic" : "edit-duplicate-symbolic"
+                        onClicked: {
+                            let rule = {
+                                "description": itemDelegate.description,
+                                "hash": itemDelegate.hash,
+                                "icon": itemDelegate.icon,
+                                "enabled": itemDelegate.enabled
+                            };
+                            if (showBuiltInRules.checked) {
+                                trayIconReplacementsModel.appendRule(rule);
+                            } else {
+                                trayIconReplacementsModel.insertRule(itemDelegate.index + 1, rule);
+                            }
+                        }
+                        hoverEnabled: true
+                        ToolTip.delay: Kirigami.Units.toolTipDelay
+                        ToolTip.text: showBuiltInRules.checked ? i18n("Copy to User Rules") : i18n("Copy rule")
+                        ToolTip.visible: copyRuleButton.hovered
+                    }
+
+                    Button {
+                        icon.name: "delete-symbolic"
+                        onClicked: trayIconReplacementsModel.removeItem(itemDelegate.index)
+                        enabled: !showBuiltInRules.checked
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugin/panelcolorizer.h
+++ b/plugin/panelcolorizer.h
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#include <QCryptographicHash>
 #include <QObject>
+#include <QPixmap>
 #include <QRectF>
 #include <QRegion>
 #include <QVariant>
@@ -18,6 +20,8 @@ class PanelColorizer : public QObject {
                                      double bottomLeftRadius, double bottomRightRadius, QPointF offset,
                                      int radiusCompensation, bool visible);
     Q_INVOKABLE void popLastVisibleMaskRegion();
+
+    Q_INVOKABLE QString getIconHash(const QVariant &variant, bool logIconNames);
 
     explicit PanelColorizer(QObject *parent = nullptr);
 


### PR DESCRIPTION
The implementation works by:

1. Gets the StatusNotifier from the system tray item model
2. Hashes the smallest icon of the item QIcon
3. Replaces the icons with provided ones (file or named icon) in the tray items Kirigam.Icon.source

The patch includes some icons for the applications that I was able to test but.

refs: https://github.com/luisbocanegra/plasma-panel-colorizer/issues/198

# Demo (Papirus icon theme + some custom icons)

Before

<img width="518" height="52" alt="Screenshot_20251229_001330" src="https://github.com/user-attachments/assets/a368975c-e30f-4fe6-9f74-74bf13ad7744" />

After

<img width="518" height="52" alt="Screenshot_20251229_001318" src="https://github.com/user-attachments/assets/67482eab-fa56-47c6-b691-76d3f53bc7b2" />