### PR TITLE
fix: Appearance/Override tabs not loading with Qt older than 6.10

### DIFF
--- a/package/contents/ui/components/FormWidgetSettings.qml
+++ b/package/contents/ui/components/FormWidgetSettings.qml
@@ -527,7 +527,10 @@ ColumnLayout {
                 textRole: "text"
                 valueRole: "value"
                 popup.height: 200
-                currentValue: root.configLocal.fontConfig.font.family
+                currentIndex: {
+                    let newValue = indexOfValue(root.configLocal.fontConfig.font.family);
+                    return newValue !== -1 ? newValue : 0;
+                }
                 onActivated: {
                     root.configLocal.fontConfig.font.family = currentValue;
                     root.updateConfig();

--- a/package/contents/ui/configAppearance.qml
+++ b/package/contents/ui/configAppearance.qml
@@ -122,7 +122,9 @@ KCM.SimpleKCM {
             elementFriendlyName: targetComponent.currentText
             followVisbility: root.followVisbility[targetComponent.currentValue]
             onElementStateChanged: root.currentState = elementState
-            onTabChanged: root.currentTab = currentTab
+            onTabChanged: currentTab => {
+                root.currentTab = currentTab;
+            }
             onUpdateConfigString: (newString, newConfig) => {
                 root.cfg_globalSettings = JSON.stringify(newConfig);
             }


### PR DESCRIPTION
Turns out ComboBox currentValue is writable only in Qt 6.10.0 and newer https://qt-project.atlassian.net/browse/QTBUG-100345

refs: https://github.com/luisbocanegra/plasma-panel-colorizer/issues/437