### PR TITLE
feat: clip widgets to their custom background

### DIFF
--- a/package/contents/ui/code/globals.js
+++ b/package/contents/ui/code/globals.js
@@ -196,6 +196,7 @@ const basePanelConfig = {
     enabled: false,
     blurBehind: false,
     flattenOnDeFloat: false,
+    backgroundClipping: false,
     backgroundColor: basePanelBgColor,
     foregroundColor: baseFgColor,
     radius: baseRadius,
@@ -209,6 +210,7 @@ const basePanelConfig = {
 const baseWidgetConfig = {
     enabled: false,
     blurBehind: false,
+    backgroundClipping: false,
     backgroundColor: baseBgColor,
     foregroundColor: baseFgColor,
     radius: baseRadius,
@@ -224,6 +226,7 @@ const baseWidgetConfig = {
 const baseTrayConfig = {
     enabled: false,
     blurBehind: false,
+    backgroundClipping: false,
     backgroundColor: baseBgColor,
     foregroundColor: baseFgColor,
     radius: baseRadius,
@@ -236,6 +239,7 @@ const baseTrayConfig = {
 
 const baseOverride = {
     blurBehind: false,
+    backgroundClipping: false,
     backgroundColor: baseBgColor,
     foregroundColor: baseFgColor,
     radius: baseRadius,

--- a/package/contents/ui/components/CustomBackground.qml
+++ b/package/contents/ui/components/CustomBackground.qml
@@ -162,6 +162,7 @@ Rectangle {
     property bool blurBehind: {
         return (isPanel && !main.anyWidgetDoingBlur && !main.anyTrayItemDoingBlur) || (isWidget) || (inTray && !main.trayWidgetBgItem?.blurBehind) ? cfg.blurBehind : false;
     }
+    property bool backgroundClipping: isWidget && (cfg.backgroundClipping ?? false) && cfgEnabled
     property string fgColor: {
         if (inTray && fgEnabled && cfgEnabled) {
             return Utils.getColor(fgColorCfg, targetIndex, color, itemType, fgColorHolder);
@@ -978,5 +979,40 @@ Rectangle {
     HoverHandler {
         id: hoverHandler
         parent: rect.target
+    }
+
+    Rectangle {
+        id: mask
+        anchors.centerIn: parent
+        height: rect.height
+        width: rect.width
+        topLeftRadius: rect.topLeftRadius
+        bottomLeftRadius: rect.bottomLeftRadius
+        topRightRadius: rect.topRightRadius
+        bottomRightRadius: rect.bottomRightRadius
+        color: "white"
+        visible: false
+    }
+
+    // clip widget content to custom background shape
+    // TODO: figure out how to do the same with the panel
+    OpacityMask {
+        anchors.fill: parent
+        anchors.leftMargin: rect.horizontal ? rect.marginLeft : undefined
+        anchors.rightMargin: rect.horizontal ? rect.marginRight : undefined
+        anchors.topMargin: rect.horizontal ? undefined : rect.marginTop
+        anchors.bottomMargin: rect.horizontal ? undefined : rect.marginBottom
+        maskSource: mask
+        visible: !!source
+        source: ShaderEffectSource {
+            live: true
+            sourceItem: {
+                if (rect.backgroundClipping) {
+                    return rect.target?.applet ?? null;
+                }
+                return null;
+            }
+            hideSource: true
+        }
     }
 }

--- a/package/contents/ui/components/FormBorder.qml
+++ b/package/contents/ui/components/FormBorder.qml
@@ -66,7 +66,7 @@ Kirigami.FormLayout {
     }
     Label {
         visible: root.elementName === "widgets" && !Number.isInteger(borderWidth.value / 100)
-        text: i18n("Use an integer when using <strong>Widget Islands</strong> to avoid rendering issues! <a href=\"https://github.com/luisbocanegra/plasma-panel-colorizer/issues/64\">See #64<a/>")
+        text: i18n("Use an integer when using <strong>Widget Islands</strong> to avoid rendering issues! <a href=\"https://github.com/luisbocanegra/plasma-panel-colorizer/issues/64\">See #64</a>")
         onLinkActivated: link => Qt.openUrlExternally(link)
         font: Kirigami.Theme.smallFont
         Layout.maximumWidth: 400

--- a/package/contents/ui/components/FormWidgetSettings.qml
+++ b/package/contents/ui/components/FormWidgetSettings.qml
@@ -385,6 +385,34 @@ ColumnLayout {
             }
         }
 
+        RowLayout {
+            Kirigami.FormData.label: i18n("Clipping (Experimental)")
+            visible: root.showFontConfig
+            CheckBox {
+                enabled: isEnabled.checked
+
+                checked: root.configLocal.backgroundClipping
+                onCheckedChanged: {
+                    root.configLocal.backgroundClipping = checked;
+                    root.updateConfig();
+                }
+            }
+        }
+
+        Label {
+            visible: root.showFontConfig
+            text: i18n("Clip the widget content to the custom background radius.<br>Clipping widgets against the panel is not supported yet but is planned for a later version, see <a href=\"https://github.com/luisbocanegra/plasma-panel-colorizer/issues/275\">#275</a>.")
+            onLinkActivated: link => Qt.openUrlExternally(link)
+            font: Kirigami.Theme.smallFont
+            wrapMode: Label.Wrap
+            color: Kirigami.Theme.disabledTextColor
+            Layout.maximumWidth: 400
+            Layout.alignment: Qt.AlignTop
+            HoverHandler {
+                cursorShape: Qt.PointingHandCursor
+            }
+        }
+
         ColumnLayout {
             visible: !plasmoid.configuration.pluginFound
             Layout.preferredWidth: 300


### PR DESCRIPTION
Clipping widgets against the panel is pending

refs: https://github.com/luisbocanegra/plasma-panel-colorizer/issues/275


<img width="411" height="130" alt="append-2026-01-30-161702" src="https://github.com/user-attachments/assets/a9accaa3-6ccb-4022-b67d-791ca99003bd" />

<img width="177" height="162" alt="append-2026-01-30-161912" src="https://github.com/user-attachments/assets/f9bc05a2-addd-4dae-b7fb-b7012afe3840" />
