### PR TITLE
fix: plasmashell crash when monitors are disconnected

### DIFF
--- a/package/contents/ui/components/CustomBackground.qml
+++ b/package/contents/ui/components/CustomBackground.qml
@@ -994,6 +994,18 @@ Rectangle {
         visible: false
     }
 
+    ShaderEffectSource {
+        id: clipSourceShaderItem
+        live: true
+        sourceItem: {
+            if (rect.backgroundClipping) {
+                return rect.target?.applet ?? null;
+            }
+            return null;
+        }
+        hideSource: true
+    }
+
     // clip widget content to custom background shape
     // TODO: figure out how to do the same with the panel
     OpacityMask {
@@ -1004,15 +1016,6 @@ Rectangle {
         anchors.bottomMargin: rect.horizontal ? undefined : rect.marginBottom
         maskSource: mask
         visible: !!source
-        source: ShaderEffectSource {
-            live: true
-            sourceItem: {
-                if (rect.backgroundClipping) {
-                    return rect.target?.applet ?? null;
-                }
-                return null;
-            }
-            hideSource: true
-        }
+        source: clipSourceShaderItem
     }
 }


### PR DESCRIPTION
While it worked, declaring the ShaderEffectSource inside OpacityMask makes plasma crash during output disconnect/reconnect, making it a sibling fixes this.

backtrace in case this is an actual bug worth looking into for someone else: https://gist.github.com/luisbocanegra/2e46bcb81179f3a7f53b2ede9891e715

refs: https://github.com/luisbocanegra/plasma-panel-colorizer/issues/458