### PR TITLE
feat: add option to blacklist spacers and enable it by default

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -113,6 +113,11 @@
         <default>{"widgets":[]}</default>
     </entry>
     <entry
+        name="blacklistSpacers"
+        type="Bool">
+        <default>true</default>
+    </entry>
+    <entry
         name="systemTrayIconsReplacementEnabled"
         type="Bool">
         <default>false</default>

--- a/package/contents/ui/code/globals.js
+++ b/package/contents/ui/code/globals.js
@@ -385,3 +385,8 @@ const editModeGridSettings = {
     majorLine: { color: "#ff0000", alpha: 0 },
     mayorLineEvery: 2,
 };
+
+const spacerWidgets = [
+    "org.kde.plasma.panelspacer",
+    "luisbocanegra.panelspacer.extended",
+];

--- a/package/contents/ui/components/CustomBackground.qml
+++ b/package/contents/ui/components/CustomBackground.qml
@@ -9,6 +9,7 @@ import org.kde.plasma.core as PlasmaCore
 import org.kde.plasma.plasmoid
 import "../code/utils.js" as Utils
 import "../code/enum.js" as Enum
+import "../code/globals.js" as Globals
 import "../code/statusNotifierItemIconRules.js" as SNIIconRules
 import "../"
 
@@ -122,7 +123,9 @@ Rectangle {
     property bool shouldHide: hideCfg?.hide ?? false
     property var widgetStatus: rect.target.applet?.plasmoid?.status ?? null
     property bool isHidden: widgetStatus === PlasmaCore.Types.HiddenStatus
-    property var blacklisted: main.blacklistedWidgets.widgets.find(widget => widget.id === widgetId && widget.name === widgetName)?.blacklisted ?? false
+    property bool blacklistSpacers: Plasmoid.configuration.blacklistSpacers
+    property bool isSpacer: Globals.spacerWidgets.includes(widgetName)
+    property var blacklisted: (main.blacklistedWidgets.widgets.find(widget => widget.id === widgetId && widget.name === widgetName)?.blacklisted ?? false) || (isSpacer && blacklistSpacers)
 
     function cornerForcedZero(cornerName) {
         if (!isPanel || !(cfg.flattenOnDeFloat ?? false))

--- a/package/contents/ui/components/WidgetCardBlacklist.qml
+++ b/package/contents/ui/components/WidgetCardBlacklist.qml
@@ -6,7 +6,7 @@ import org.kde.kirigami as Kirigami
 Kirigami.AbstractCard {
     id: root
 
-    property var widget
+    required property var model
 
     signal updateWidget(bool hide)
 
@@ -14,21 +14,21 @@ Kirigami.AbstractCard {
 
     contentItem: RowLayout {
         Kirigami.Icon {
-            width: Kirigami.Units.gridUnit
-            height: width
-            source: root.widget.icon
+            Layout.preferredWidth: Kirigami.Units.iconSizes.medium
+            Layout.preferredHeight: Layout.preferredWidth
+            source: root.model.icon
         }
 
         ColumnLayout {
             Label {
-                text: root.widget.title
+                text: root.model.title
                 Layout.fillWidth: true
                 wrapMode: Label.Wrap
             }
 
             RowLayout {
                 TextEdit {
-                    text: root.widget.name
+                    text: root.model.name
                     opacity: 0.6
                     readOnly: true
                     color: Kirigami.Theme.textColor
@@ -38,7 +38,7 @@ Kirigami.AbstractCard {
                 }
 
                 TextEdit {
-                    text: root.widget.id
+                    text: root.model.id
                     opacity: 0.6
                     readOnly: true
                     color: Kirigami.Theme.textColor
@@ -54,7 +54,7 @@ Kirigami.AbstractCard {
         }
 
         Rectangle {
-            visible: root.widget.inTray
+            visible: root.model.inTray
             color: Kirigami.Theme.highlightColor
             Kirigami.Theme.colorSet: root.Kirigami.Theme["Selection"]
             radius: parent.height / 2
@@ -78,7 +78,7 @@ Kirigami.AbstractCard {
 
             text: i18n("Blacklist")
             checkable: true
-            checked: root.widget.blacklisted ?? false
+            checked: root.model.blacklisted ?? false
             icon.name: checked ? "checkmark-symbolic" : "dialog-close-symbolic"
             onCheckedChanged: {
                 root.updateWidget(hideCheckbox.checked);

--- a/package/contents/ui/configBlacklistWidgets.qml
+++ b/package/contents/ui/configBlacklistWidgets.qml
@@ -1,8 +1,10 @@
+pragma ComponentBehavior: Bound
 import QtCore
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import "code/utils.js" as Utils
+import "code/globals.js" as Globals
 import "components" as Components
 import org.kde.kcmutils as KCM
 import org.kde.kirigami as Kirigami
@@ -21,6 +23,7 @@ KCM.SimpleKCM {
     property string configDir: StandardPaths.writableLocation(StandardPaths.HomeLocation).toString().substring(7) + "/.config/panel-colorizer/"
     property string importCmd: "cat '" + configDir + "blacklistWidgets.json'"
     property string crateConfigDirCmd: "mkdir -p " + configDir
+    property alias cfg_blacklistSpacers: blacklistSpacers.checked
 
     function updateConfig() {
         console.log("updateConfig()");
@@ -70,7 +73,8 @@ KCM.SimpleKCM {
             const icon = widget.icon;
             const inTray = widget.inTray;
             const globalShortcut = widget.globalShortcut ?? "";
-            if (inTray)
+            const isSpacer = Globals.spacerWidgets.includes(name);
+            if (inTray || (isSpacer && cfg_blacklistSpacers))
                 continue;
             widgetsModel.append({
                 id,
@@ -118,6 +122,13 @@ KCM.SimpleKCM {
         updateWidgetsModel();
     }
 
+    onCfg_blacklistSpacersChanged: {
+        if (!loaded)
+            return;
+
+        initWidgets();
+    }
+
     ListModel {
         id: widgetsModel
     }
@@ -156,6 +167,17 @@ KCM.SimpleKCM {
             type: Kirigami.MessageType.Information
         }
 
+        Kirigami.FormLayout {
+            CheckBox {
+                id: blacklistSpacers
+                text: i18n("Blacklist spacers")
+                checked: root.cfg_blacklistSpacers
+                onCheckedChanged: {
+                    root.updateConfig();
+                }
+            }
+        }
+
         RowLayout {
             Button {
                 text: i18n("Remove all")
@@ -182,9 +204,9 @@ KCM.SimpleKCM {
                 model: widgetsModel
 
                 delegate: Components.WidgetCardBlacklist {
-                    widget: model
+                    required property int index
                     onUpdateWidget: blacklisted => {
-                        if (!loaded)
+                        if (!root.loaded)
                             return;
 
                         widgetsModel.set(index, {


### PR DESCRIPTION
Disabling customization for spacers is one of the most asked questions, even if we had way to override for a while and now have a easy way to blacklist them, making a widget that is not interactive visible by default is not what everyone would expect and may be seem as a bug

refs: #146 #182 #294 #401 #509