### PR TITLE
fix: crashes and slowness in appearance/override configuration tabs

### DIFF
--- a/package/contents/ui/components/FontFamilyChooser.qml
+++ b/package/contents/ui/components/FontFamilyChooser.qml
@@ -1,0 +1,89 @@
+pragma ComponentBehavior: Bound
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+import org.kde.kitemmodels as KItemModels
+
+ColumnLayout {
+    id: root
+    property string selectedFont: "Noto Sans"
+    signal fontSelected(string font)
+
+    ListModel {
+        id: fontModel
+        Component.onCompleted: {
+            const fonts = Qt.fontFamilies();
+            for (const font of fonts) {
+                append({
+                    "name": font
+                });
+            }
+        }
+    }
+
+    KItemModels.KSortFilterProxyModel {
+        id: fontsFilteredModel
+        sourceModel: fontModel
+        filterRoleName: "name"
+        filterRowCallback: (sourceRow, sourceParent) => {
+            return sourceModel.data(sourceModel.index(sourceRow, 0, sourceParent), filterRole).toLowerCase().includes(searchField.text.toLowerCase());
+        }
+    }
+
+    Kirigami.SearchField {
+        id: searchField
+        placeholderText: "Search fonts"
+        Layout.fillWidth: true
+        onTextChanged: fontsFilteredModel.setFilterFixedString(text)
+    }
+
+    ScrollView {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        ListView {
+            id: view
+            width: parent.width
+            clip: true
+            height: parent.height
+            model: fontsFilteredModel
+            reuseItems: false
+            delegate: RadioDelegate {
+                id: delegate
+                required property string modelData
+                required property int index
+                width: view.width
+                text: delegate.modelData
+                checked: delegate.modelData === root.selectedFont
+                onCheckedChanged: {
+                    if (checked) {
+                        root.selectedFont = modelData;
+                        root.fontSelected(modelData);
+                    }
+                }
+            }
+            Component.onCompleted: {
+                Qt.callLater(() => {
+                    let index = -1;
+                    for (let i = 0; i < fontsFilteredModel.rowCount(); ++i) {
+                        const modelIndex = fontsFilteredModel.index(i, 0);
+                        if (fontsFilteredModel.data(modelIndex, Qt.DisplayRole) === root.selectedFont) {
+                            index = i;
+                            break;
+                        }
+                    }
+
+                    if (index !== -1) {
+                        view.positionViewAtIndex(index, ListView.Beginning);
+                    } else {
+                        const modelIndex = fontsFilteredModel.index(0, 0);
+                        if (modelIndex) {
+                            root.selectedFont = fontsFilteredModel.data(modelIndex, Qt.DisplayRole);
+                        }
+                        view.positionViewAtIndex(0, ListView.Beginning);
+                    }
+                });
+            }
+        }
+    }
+}

--- a/package/contents/ui/components/FormBorder.qml
+++ b/package/contents/ui/components/FormBorder.qml
@@ -6,8 +6,6 @@ import org.kde.kirigami as Kirigami
 Kirigami.FormLayout {
     id: root
 
-    // required to align with parent form
-    property alias formLayout: root
     property bool isSection: true
     property string sectionName
     // wether read from the string or existing config object
@@ -23,9 +21,6 @@ Kirigami.FormLayout {
     function updateConfig() {
         updateConfigString(configString, config);
     }
-
-    twinFormLayouts: parentLayout
-    Layout.fillWidth: true
 
     Kirigami.Separator {
         Kirigami.FormData.isSection: isSection

--- a/package/contents/ui/components/FormColors.qml
+++ b/package/contents/ui/components/FormColors.qml
@@ -7,8 +7,6 @@ import org.kde.kirigami as Kirigami
 Kirigami.FormLayout {
     id: root
 
-    // required to align with parent form
-    property alias formLayout: root
     property bool isSection: true
     property string sectionName
     // wether read from the string or existing config object
@@ -37,9 +35,6 @@ Kirigami.FormLayout {
     function updateConfig() {
         updateConfigString(configString, config);
     }
-
-    twinFormLayouts: parentLayout
-    Layout.fillWidth: true
 
     ListModel {
         id: themeColorSetModel

--- a/package/contents/ui/components/FormPadding.qml
+++ b/package/contents/ui/components/FormPadding.qml
@@ -6,8 +6,6 @@ import org.kde.kirigami as Kirigami
 Kirigami.FormLayout {
     id: shapeRoot
 
-    // required to align with parent form
-    property alias formLayout: shapeRoot
     property bool isSection: true
     // wether read from the string or existing config object
     property bool handleString
@@ -20,9 +18,6 @@ Kirigami.FormLayout {
     function updateConfig() {
         updateConfigString(configString, config);
     }
-
-    twinFormLayouts: parentLayout
-    Layout.fillWidth: true
 
     Kirigami.Separator {
         Kirigami.FormData.isSection: isSection
@@ -93,7 +88,6 @@ Kirigami.FormLayout {
                     toolTipText: i18n("Horizontal and vertical padding only work properly when the panel is on the same orientation.")
                 }
             }
-
         }
     }
 }

--- a/package/contents/ui/components/FormShadow.qml
+++ b/package/contents/ui/components/FormShadow.qml
@@ -6,8 +6,6 @@ import org.kde.kirigami as Kirigami
 Kirigami.FormLayout {
     id: shadowRoot
 
-    // required to align with parent form
-    property alias formLayout: shadowRoot
     property bool isSection: true
     property string sectionName
     // wether read from the string or existing config object
@@ -21,9 +19,6 @@ Kirigami.FormLayout {
     function updateConfig() {
         updateConfigString(configString, config);
     }
-
-    twinFormLayouts: parentLayout
-    Layout.fillWidth: true
 
     Kirigami.Separator {
         Kirigami.FormData.isSection: isSection

--- a/package/contents/ui/components/FormShape.qml
+++ b/package/contents/ui/components/FormShape.qml
@@ -7,8 +7,6 @@ import "../"
 Kirigami.FormLayout {
     id: shapeRoot
 
-    // required to align with parent form
-    property alias formLayout: shapeRoot
     property bool isSection: true
     // wether read from the string or existing config object
     property bool handleString
@@ -22,9 +20,6 @@ Kirigami.FormLayout {
     function updateConfig() {
         updateConfigString(configString, config);
     }
-
-    twinFormLayouts: parentLayout
-    Layout.fillWidth: true
 
     Kirigami.Separator {
         Kirigami.FormData.isSection: true

--- a/package/contents/ui/components/FormWidgetSettings.qml
+++ b/package/contents/ui/components/FormWidgetSettings.qml
@@ -36,18 +36,6 @@ ColumnLayout {
         return false;
     }
 
-    property var fontsModel: {
-        let arr = [];
-        const fonts = Qt.fontFamilies();
-        for (var i = 0; i < fonts.length; i++) {
-            arr.push({
-                text: fonts[i],
-                value: fonts[i]
-            });
-        }
-        return arr;
-    }
-
     property string stateName: {
         if (elementState === Enum.WidgetStates.Normal) {
             return "normal";
@@ -118,15 +106,31 @@ ColumnLayout {
     signal updateConfigString(string configString, var config)
     signal tabChanged(int currentTab)
 
+    Timer {
+        id: delayedUpdateTimer
+        interval: 100
+        repeat: false
+        onTriggered: {
+            Qt.callLater(() => {
+                if (elementName) {
+                    config[elementName][stateName] = configLocal;
+                } else {
+                    config[stateName] = configLocal;
+                }
+                updateConfigString(JSON.stringify(config, null, null), config);
+            });
+        }
+    }
+
     function updateConfig() {
-        Qt.callLater(() => {
-            if (elementName) {
-                config[elementName][stateName] = configLocal;
-            } else {
-                config[stateName] = configLocal;
-            }
-            updateConfigString(JSON.stringify(config, null, null), config);
-        });
+        if (!ready) {
+            return;
+        }
+        if (delayedUpdateTimer.running) {
+            delayedUpdateTimer.restart();
+        } else {
+            delayedUpdateTimer.start();
+        }
     }
 
     onCurrentTabChanged: {
@@ -138,9 +142,9 @@ ColumnLayout {
     }
 
     Kirigami.FormLayout {
+        id: mainForm
         // required to align with parent form
         property alias formLayout: root
-        twinFormLayouts: parentLayout
         Layout.fillWidth: true
 
         RowLayout {
@@ -161,7 +165,7 @@ ColumnLayout {
             }
         }
         Label {
-            visible: !!!root.config.nativePanel.background.enabled && elementName === "panel" && root.elementState === Enum.WidgetStates.Normal
+            visible: (!!!root.config?.nativePanel?.background?.enabled) && elementName === "panel" && root.elementState === Enum.WidgetStates.Normal
             text: i18n("⚠️ Disabling this breaks the panel clickable area and applet dialogs positioning when the panel is in floating mode! See <a href=\"%1\">#80</a>.", "https://github.com/luisbocanegra/plasma-panel-colorizer/issues/80")
             onLinkActivated: link => Qt.openUrlExternally(link)
             font: Kirigami.Theme.smallFont
@@ -485,6 +489,11 @@ ColumnLayout {
                 cursorShape: Qt.PointingHandCursor
             }
         }
+        Component.onCompleted: function () {
+            if (typeof appearanceRoot !== "undefined") {
+                twinFormLayouts.push(appearanceRoot.parentLayout);
+            }
+        }
     }
 
     Kirigami.NavigationTabBar {
@@ -550,7 +559,7 @@ ColumnLayout {
                 from: 0
                 to: 999
                 onValueModified: {
-                    if (!enabled)
+                    if (!enabled || !root.ready)
                         return;
 
                     configLocal.spacing = value;
@@ -574,6 +583,8 @@ ColumnLayout {
             text: i18n("Enable")
             checked: root.configLocal.fontConfig.enabled
             onCheckedChanged: {
+                if (!root.ready)
+                    return;
                 root.configLocal.fontConfig.enabled = checked;
                 root.updateConfig();
             }
@@ -593,6 +604,24 @@ ColumnLayout {
                 cursorShape: Qt.PointingHandCursor
             }
         }
+        // preview
+        TextArea {
+            visible: (root.showFontConfig) && root.currentTab === 4
+            text: i18n("12345678900\nABCDEFGHIJKLMNOPQRSTUVWXYZ\nabcdefghijklmnopqrstuvwxyz")
+            Kirigami.SpellCheck.enabled: false
+            function reload() {
+                font.family = root.configLocal.fontConfig.font.familyOverride ? root.configLocal.fontConfig.font.family : Kirigami.Theme.defaultFont.family;
+                font.italic = root.configLocal.fontConfig.font.italicOverride ? root.configLocal.fontConfig.font.italic : Kirigami.Theme.defaultFont.italic;
+                font.underline = root.configLocal.fontConfig.font.underlineOverride ? root.configLocal.fontConfig.font.underline : Kirigami.Theme.defaultFont.underline;
+                font.weight = root.configLocal.fontConfig.font.weightOverride ? root.configLocal.fontConfig.font.weight : Kirigami.Theme.defaultFont.weight;
+                font.pointSize = root.configLocal.fontConfig.font.pointSizeOverride ? root.configLocal.fontConfig.font.pointSize : Kirigami.Theme.defaultFont.pointSize;
+            }
+            Component.onCompleted: {
+                root.updateConfigString.connect(() => {
+                    reload();
+                });
+            }
+        }
         RowLayout {
             Kirigami.FormData.label: i18n("Font family:")
             visible: (root.showFontConfig) && root.currentTab === 4
@@ -602,24 +631,43 @@ ColumnLayout {
                 text: i18n("Override")
                 checked: root.configLocal.fontConfig.font.familyOverride
                 onCheckedChanged: {
+                    if (!root.ready)
+                        return;
                     root.configLocal.fontConfig.font.familyOverride = checked;
                     root.updateConfig();
                 }
             }
-            ComboBox {
-                model: root.fontsModel
-                textRole: "text"
-                valueRole: "value"
-                popup.height: 200
-                currentIndex: {
-                    let newValue = indexOfValue(root.configLocal.fontConfig.font.family);
-                    return newValue !== -1 ? newValue : 0;
-                }
-                onActivated: {
-                    root.configLocal.fontConfig.font.family = currentValue;
+        }
+
+        Component {
+            id: fontFamilyPicker
+            FontFamilyChooser {
+                Layout.fillWidth: true
+                height: 200
+                enabled: familyOverride.checked
+                selectedFont: root.configLocal.fontConfig.font.family
+                onFontSelected: font => {
+                    if (!root.ready)
+                        return;
+                    root.configLocal.fontConfig.font.family = font;
                     root.updateConfig();
                 }
-                enabled: familyOverride.checked
+            }
+        }
+
+        Loader {
+            sourceComponent: fontFamilyPicker
+            active: (root.showFontConfig) && root.currentTab === 4
+            Layout.fillWidth: true
+            visible: active
+            onLoaded: {
+                item.selectedFont = root.configLocal.fontConfig.font.family;
+                item.fontSelected.connect(function (font) {
+                    if (!root.ready)
+                        return;
+                    root.configLocal.fontConfig.font.family = font;
+                    root.updateConfig();
+                });
             }
         }
 
@@ -632,6 +680,8 @@ ColumnLayout {
                 text: i18n("Override")
                 checked: root.configLocal.fontConfig.font.italicOverride
                 onCheckedChanged: {
+                    if (!root.ready)
+                        return;
                     root.configLocal.fontConfig.font.italicOverride = checked;
                     root.updateConfig();
                 }
@@ -640,6 +690,8 @@ ColumnLayout {
                 text: i18n("Enable")
                 checked: root.configLocal.fontConfig.font.italic
                 onCheckedChanged: {
+                    if (!root.ready)
+                        return;
                     root.configLocal.fontConfig.font.italic = checked;
                     root.updateConfig();
                 }
@@ -655,6 +707,8 @@ ColumnLayout {
                 text: i18n("Override")
                 checked: root.configLocal.fontConfig.font.underlineOverride
                 onCheckedChanged: {
+                    if (!root.ready)
+                        return;
                     root.configLocal.fontConfig.font.underlineOverride = checked;
                     root.updateConfig();
                 }
@@ -663,6 +717,8 @@ ColumnLayout {
                 text: i18n("Enable")
                 checked: root.configLocal.fontConfig.font.underline
                 onCheckedChanged: {
+                    if (!root.ready)
+                        return;
                     root.configLocal.fontConfig.font.underline = checked;
                     root.updateConfig();
                 }
@@ -678,6 +734,8 @@ ColumnLayout {
                 text: i18n("Override")
                 checked: root.configLocal.fontConfig.font.weightOverride
                 onCheckedChanged: {
+                    if (!root.ready)
+                        return;
                     root.configLocal.fontConfig.font.weightOverride = checked;
                     root.updateConfig();
                 }
@@ -688,6 +746,8 @@ ColumnLayout {
                 stepSize: 100
                 value: root.configLocal.fontConfig.font.weight
                 onValueChanged: {
+                    if (!root.ready)
+                        return;
                     root.configLocal.fontConfig.font.weight = value;
                     root.updateConfig();
                 }
@@ -703,6 +763,8 @@ ColumnLayout {
                 text: i18n("Override")
                 checked: root.configLocal.fontConfig.font.pointSizeOverride
                 onCheckedChanged: {
+                    if (!root.ready)
+                        return;
                     root.configLocal.fontConfig.font.pointSizeOverride = checked;
                     root.updateConfig();
                 }
@@ -713,6 +775,8 @@ ColumnLayout {
                 stepSize: 1
                 value: root.configLocal.fontConfig.font.pointSize
                 onValueChanged: {
+                    if (!root.ready)
+                        return;
                     root.configLocal.fontConfig.font.pointSize = value;
                     root.updateConfig();
                 }
@@ -727,10 +791,13 @@ ColumnLayout {
     }
 
     FormColors {
+        twinFormLayouts: [mainForm]
         enabled: root.isEnabled
         visible: currentTab === 0
         config: root.configLocal.backgroundColor
         onUpdateConfigString: (newString, newConfig) => {
+            if (!root.ready)
+                return;
             root.configLocal.backgroundColor = newConfig;
             root.updateConfig();
         }
@@ -742,12 +809,15 @@ ColumnLayout {
     }
 
     FormColors {
+        twinFormLayouts: [mainForm]
         enabled: root.isEnabled
         // the panel does not support foreground customization
         visible: currentTab === 0 && elementName !== "panel"
         config: root.configLocal.foregroundColor
         isSection: true
         onUpdateConfigString: (newString, newConfig) => {
+            if (!root.ready)
+                return;
             root.configLocal.foregroundColor = newConfig;
             root.updateConfig();
         }
@@ -756,10 +826,13 @@ ColumnLayout {
     }
 
     FormShape {
+        twinFormLayouts: [mainForm]
         enabled: root.isEnabled
         visible: currentTab === 1
         config: root.configLocal
         onUpdateConfigString: (newString, newConfig) => {
+            if (!root.ready)
+                return;
             root.configLocal = newConfig;
             root.updateConfig();
         }
@@ -767,22 +840,28 @@ ColumnLayout {
     }
 
     FormPadding {
+        twinFormLayouts: [mainForm]
         enabled: root.isEnabled
         visible: currentTab === 1 && elementName === "panel"
         config: root.configLocal
         onUpdateConfigString: (newString, newConfig) => {
+            if (!root.ready)
+                return;
             root.configLocal = newConfig;
             root.updateConfig();
         }
     }
 
     FormBorder {
+        twinFormLayouts: [mainForm]
         isSection: true
         sectionName: i18n("Primary Border")
         enabled: root.isEnabled
         visible: currentTab === 2
         config: root.configLocal.border
         onUpdateConfigString: (newString, newConfig) => {
+            if (!root.ready)
+                return;
             root.configLocal.border = newConfig;
             root.updateConfig();
         }
@@ -790,11 +869,14 @@ ColumnLayout {
     }
 
     FormColors {
+        twinFormLayouts: [mainForm]
         isSection: false
         enabled: root.isEnabled
         visible: currentTab === 2
         config: root.configLocal.border.color
         onUpdateConfigString: (newString, newConfig) => {
+            if (!root.ready)
+                return;
             root.configLocal.border.color = newConfig;
             root.updateConfig();
         }
@@ -802,12 +884,15 @@ ColumnLayout {
     }
 
     FormBorder {
+        twinFormLayouts: [mainForm]
         isSection: true
         sectionName: i18n("Secondary Border")
         enabled: root.isEnabled
         visible: currentTab === 2
         config: root.configLocal.borderSecondary
         onUpdateConfigString: (newString, newConfig) => {
+            if (!root.ready)
+                return;
             root.configLocal.borderSecondary = newConfig;
             root.updateConfig();
         }
@@ -815,11 +900,14 @@ ColumnLayout {
     }
 
     FormColors {
+        twinFormLayouts: [mainForm]
         isSection: false
         enabled: root.isEnabled
         visible: currentTab === 2
         config: root.configLocal.borderSecondary.color
         onUpdateConfigString: (newString, newConfig) => {
+            if (!root.ready)
+                return;
             root.configLocal.borderSecondary.color = newConfig;
             root.updateConfig();
         }
@@ -827,10 +915,13 @@ ColumnLayout {
     }
 
     FormShadow {
+        twinFormLayouts: [mainForm]
         enabled: root.isEnabled
         visible: currentTab === 3
         config: root.configLocal.shadow.background
         onUpdateConfigString: (newString, newConfig) => {
+            if (!root.ready)
+                return;
             root.configLocal.shadow.background = newConfig;
             root.updateConfig();
         }
@@ -838,10 +929,13 @@ ColumnLayout {
     }
 
     FormColors {
+        twinFormLayouts: [mainForm]
         enabled: root.isEnabled
         visible: currentTab === 3
         config: root.configLocal.shadow.background.color
         onUpdateConfigString: (newString, newConfig) => {
+            if (!root.ready)
+                return;
             root.configLocal.shadow.background.color = newConfig;
             root.updateConfig();
         }
@@ -851,10 +945,13 @@ ColumnLayout {
     }
 
     FormShadow {
+        twinFormLayouts: [mainForm]
         enabled: root.isEnabled
         visible: currentTab === 3 && elementName !== "panel"
         config: root.configLocal.shadow.foreground
         onUpdateConfigString: (newString, newConfig) => {
+            if (!root.ready)
+                return;
             root.configLocal.shadow.foreground = newConfig;
             root.updateConfig();
         }
@@ -862,10 +959,13 @@ ColumnLayout {
     }
 
     FormColors {
+        twinFormLayouts: [mainForm]
         enabled: root.isEnabled
         visible: currentTab === 3 && elementName !== "panel"
         config: root.configLocal.shadow.foreground.color
         onUpdateConfigString: (newString, newConfig) => {
+            if (!root.ready)
+                return;
             root.configLocal.shadow.foreground.color = newConfig;
             root.updateConfig();
         }

--- a/package/contents/ui/configAppearance.qml
+++ b/package/contents/ui/configAppearance.qml
@@ -1,7 +1,7 @@
+pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import "code/utils.js" as Utils
 import "code/globals.js" as Globals
 import "components" as Components
 import org.kde.kcmutils as KCM
@@ -9,13 +9,15 @@ import org.kde.kirigami as Kirigami
 import org.kde.plasma.plasmoid
 
 KCM.SimpleKCM {
-    id: root
+    id: appearanceRoot
+    property alias parentLayout: parentLayout
 
     property int currentTab
     property int currentState
     property string cfg_globalSettings
     property alias cfg_isEnabled: headerComponent.isEnabled
     property bool ready: false
+    property var settingsItem: null
     property var followVisbility: {
         "widgets": {
             "background": {
@@ -56,7 +58,11 @@ KCM.SimpleKCM {
     }
 
     ColumnLayout {
+        id: layout
         enabled: cfg_isEnabled
+        width: appearanceRoot.availableWidth
+        height: Math.max(implicitHeight, appearanceRoot.availableHeight)
+        spacing: 0
 
         Kirigami.InlineMessage {
             Layout.fillWidth: true
@@ -83,7 +89,6 @@ KCM.SimpleKCM {
             id: parentLayout
 
             Layout.fillWidth: true
-
             RowLayout {
                 Kirigami.FormData.label: i18n("Element:")
                 ComboBox {
@@ -116,21 +121,61 @@ KCM.SimpleKCM {
             }
         }
 
-        Components.FormWidgetSettings {
+        Component {
             id: settingsComp
-            currentTab: root.currentTab
-            configString: root.cfg_globalSettings
-            handleString: true
-            elementState: root.currentState
-            elementName: targetComponent.currentValue
-            elementFriendlyName: targetComponent.currentText
-            followVisbility: root.followVisbility[targetComponent.currentValue]
-            onElementStateChanged: root.currentState = elementState
-            onTabChanged: currentTab => {
-                root.currentTab = currentTab;
+            Components.FormWidgetSettings {
+                currentTab: appearanceRoot.currentTab
+                configString: appearanceRoot.cfg_globalSettings
+                handleString: true
+                elementState: appearanceRoot.currentState
+                elementName: targetComponent.currentValue
+                elementFriendlyName: targetComponent.currentText
+                followVisbility: appearanceRoot.followVisbility[targetComponent.currentValue]
+                onElementStateChanged: appearanceRoot.currentState = elementState
+                onTabChanged: currentTab => {
+                    appearanceRoot.currentTab = currentTab;
+                }
+                onUpdateConfigString: (newString, newConfig) => {
+                    if (!appearanceRoot.ready) {
+                        return;
+                    }
+                    Qt.callLater(() => {
+                        console.error("Components.FormWidgetSettings, Updated config string");
+                        appearanceRoot.cfg_globalSettings = JSON.stringify(newConfig);
+                    });
+                }
             }
-            onUpdateConfigString: (newString, newConfig) => {
-                root.cfg_globalSettings = JSON.stringify(newConfig);
+        }
+
+        Component.onCompleted: {
+            Qt.callLater(() => {
+                appearanceRoot.settingsItem = settingsComp.createObject(layout);
+                appearanceRoot.ready = true;
+            });
+        }
+        Item {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            visible: !appearanceRoot.settingsItem
+            Kirigami.LoadingPlaceholder {
+                anchors.centerIn: parent
+            }
+        }
+    }
+
+    Component.onDestruction: {
+        if (appearanceRoot.settingsItem) {
+            appearanceRoot.settingsItem.destroy();
+            appearanceRoot.settingsItem = null;
+        }
+    }
+
+    Connections {
+        target: Qt.application
+        function onAboutToQuit() {
+            if (appearanceRoot.settingsItem) {
+                appearanceRoot.settingsItem.destroy();
+                appearanceRoot.settingsItem = null;
             }
         }
     }

--- a/package/contents/ui/configGlobalWidgetOverrides.qml
+++ b/package/contents/ui/configGlobalWidgetOverrides.qml
@@ -10,7 +10,8 @@ import "code/utils.js" as Utils
 import "code/globals.js" as Globals
 
 KCM.SimpleKCM {
-    id: root
+    id: appearanceRoot
+    property alias parentLayout: parentLayout
     property alias cfg_isEnabled: headerComponent.isEnabled
     property string cfg_panelWidgets
     property bool clearing: false
@@ -80,7 +81,7 @@ KCM.SimpleKCM {
                 const content = stdout.trim().split("\n");
                 try {
                     const newConfig = JSON.parse(content);
-                    root.importConfig(newConfig);
+                    appearanceRoot.importConfig(newConfig);
                 } catch (e) {
                     console.error(e);
                 }
@@ -137,7 +138,7 @@ KCM.SimpleKCM {
                 text: i18n("Restore default (removes all overrides)")
                 icon.name: "kt-restore-defaults-symbolic"
                 onClicked: {
-                    root.restoreSettings();
+                    appearanceRoot.restoreSettings();
                 }
                 Layout.fillWidth: true
             }
@@ -166,12 +167,12 @@ KCM.SimpleKCM {
             Layout.maximumWidth: 500
             Layout.alignment: Qt.AlignHCenter
             Repeater {
-                model: Object.keys(root.configOverrides)
+                model: Object.keys(appearanceRoot.configOverrides)
                 delegate: Components.WidgetCardOverride {
                     onDeleteOverride: name => {
                         delete configOverrides[name];
                         showingConfig = false;
-                        root.updateConfig();
+                        appearanceRoot.updateConfig();
                     }
                     onEditingName: name => {
                         overrideName = name;
@@ -188,16 +189,11 @@ KCM.SimpleKCM {
                         nextOverride++;
                     }
                     configOverrides[`Global Override ${nextOverride}`] = Globals.baseOverrideConfig;
-                    root.updateConfig();
+                    appearanceRoot.updateConfig();
                 }
             }
         }
 
-        // Label {
-        //     text: overrideName
-        // }
-
-        property alias parentLayout: parentLayout
         ColumnLayout {
             visible: showingConfig && userInput
             Kirigami.FormLayout {
@@ -224,7 +220,7 @@ KCM.SimpleKCM {
                             configOverrides[nameField.text] = configOverrides[overrideName];
                             delete configOverrides[overrideName];
                             overrideName = nameField.text;
-                            root.updateConfig();
+                            appearanceRoot.updateConfig();
                         }
                     }
                 }
@@ -234,7 +230,7 @@ KCM.SimpleKCM {
                         checked: configOverrides[overrideName]?.disabledFallback || false
                         onCheckedChanged: {
                             configOverrides[overrideName].disabledFallback = checked;
-                            root.updateConfig();
+                            appearanceRoot.updateConfig();
                         }
                     }
                     Kirigami.ContextualHelpButton {
@@ -247,20 +243,20 @@ KCM.SimpleKCM {
                 asynchronous: true
                 sourceComponent: showingConfig ? settingsComp : null
                 onLoaded: {
-                    item.width = root.availableWidth;
+                    item.width = appearanceRoot.availableWidth;
                     item.config = configOverrides[overrideName];
                     item.onUpdateConfigString.connect((newString, config) => {
                         configOverrides[overrideName] = config;
-                        root.updateConfig();
+                        appearanceRoot.updateConfig();
                     });
-                    item.elementState = root.currentState;
-                    item.currentTab = root.currentTab;
+                    item.elementState = appearanceRoot.currentState;
+                    item.currentTab = appearanceRoot.currentTab;
                     item.elementFriendlyName = i18n("Widgets");
                     item.tabChanged.connect(currentTab => {
-                        root.currentTab = currentTab;
+                        appearanceRoot.currentTab = currentTab;
                     });
                     item.elementStateChanged.connect(() => {
-                        root.currentState = item.elementState;
+                        appearanceRoot.currentState = item.elementState;
                         componentLoader.sourceComponent = null;
                         componentLoader.sourceComponent = Qt.binding(() => showingConfig ? settingsComp : null);
                     });
@@ -295,7 +291,7 @@ KCM.SimpleKCM {
                 model: widgetsModel
                 delegate: Components.WidgetCardConfig {
                     widget: model
-                    configOverrides: Object.keys(root.configOverrides)
+                    configOverrides: Object.keys(appearanceRoot.configOverrides)
                     overrideAssociations: associationsModel
                     currentOverrides: associationsModel[Utils.getWidgetConfigIdx(id, name, associationsModel)]?.presets || []
                     onAddOverride: (preset, index) => {
@@ -316,17 +312,17 @@ KCM.SimpleKCM {
                         } else {
                             associationsModel[asocIndex].presets[index] = preset;
                         }
-                        root.updateConfig();
+                        appearanceRoot.updateConfig();
                     }
                     onRemoveOverride: index => {
                         const asocIndex = Utils.getWidgetConfigIdx(id, name, associationsModel);
                         associationsModel[asocIndex].presets.splice(index, 1);
-                        root.updateConfig();
+                        appearanceRoot.updateConfig();
                     }
                     onClearOverrides: () => {
                         const asocIndex = Utils.getWidgetConfigIdx(id, name, associationsModel);
                         associationsModel[asocIndex].presets = [];
-                        root.updateConfig();
+                        appearanceRoot.updateConfig();
                     }
                 }
             }

--- a/package/contents/ui/configPresetWidgetOverrides.qml
+++ b/package/contents/ui/configPresetWidgetOverrides.qml
@@ -10,7 +10,8 @@ import "code/utils.js" as Utils
 import "code/globals.js" as Globals
 
 KCM.SimpleKCM {
-    id: root
+    id: appearanceRoot
+    property alias parentLayout: parentLayout
     property alias cfg_isEnabled: headerComponent.isEnabled
     property string cfg_panelWidgets
     property bool clearing: false
@@ -127,7 +128,7 @@ KCM.SimpleKCM {
                 text: i18n("Restore default (removes all overrides)")
                 icon.name: "kt-restore-defaults-symbolic"
                 onClicked: {
-                    root.restoreSettings();
+                    appearanceRoot.restoreSettings();
                 }
                 Layout.fillWidth: true
             }
@@ -151,12 +152,12 @@ KCM.SimpleKCM {
             Layout.maximumWidth: 500
             Layout.alignment: Qt.AlignHCenter
             Repeater {
-                model: Object.keys(root.configOverrides)
+                model: Object.keys(appearanceRoot.configOverrides)
                 delegate: Components.WidgetCardOverride {
                     onDeleteOverride: name => {
                         delete configOverrides[name];
                         showingConfig = false;
-                        root.updateConfig();
+                        appearanceRoot.updateConfig();
                     }
                     onEditingName: name => {
                         overrideName = name;
@@ -173,7 +174,7 @@ KCM.SimpleKCM {
                         nextOverride++;
                     }
                     configOverrides[`Preset Override ${nextOverride}`] = Globals.baseOverrideConfig;
-                    root.updateConfig();
+                    appearanceRoot.updateConfig();
                 }
             }
         }
@@ -205,7 +206,7 @@ KCM.SimpleKCM {
                             configOverrides[nameField.text] = configOverrides[overrideName];
                             delete configOverrides[overrideName];
                             overrideName = nameField.text;
-                            root.updateConfig();
+                            appearanceRoot.updateConfig();
                         }
                     }
                 }
@@ -215,20 +216,20 @@ KCM.SimpleKCM {
                 asynchronous: true
                 sourceComponent: showingConfig ? settingsComp : null
                 onLoaded: {
-                    item.width = root.availableWidth;
+                    item.width = appearanceRoot.availableWidth;
                     item.config = configOverrides[overrideName];
                     item.onUpdateConfigString.connect((newString, config) => {
                         configOverrides[overrideName] = config;
-                        root.updateConfig();
+                        appearanceRoot.updateConfig();
                     });
-                    item.elementState = root.currentState;
-                    item.currentTab = root.currentTab;
+                    item.elementState = appearanceRoot.currentState;
+                    item.currentTab = appearanceRoot.currentTab;
                     item.elementFriendlyName = i18n("Widgets");
                     item.tabChanged.connect(currentTab => {
-                        root.currentTab = currentTab;
+                        appearanceRoot.currentTab = currentTab;
                     });
                     item.elementStateChanged.connect(() => {
-                        root.currentState = item.elementState;
+                        appearanceRoot.currentState = item.elementState;
                         componentLoader.sourceComponent = null;
                         componentLoader.sourceComponent = Qt.binding(() => showingConfig ? settingsComp : null);
                     });
@@ -263,7 +264,7 @@ KCM.SimpleKCM {
                 model: widgetsModel
                 delegate: Components.WidgetCardConfig {
                     widget: model
-                    configOverrides: Object.keys(root.configOverrides)
+                    configOverrides: Object.keys(appearanceRoot.configOverrides)
                     overrideAssociations: associationsModel
                     currentOverrides: associationsModel[Utils.getWidgetConfigIdx(id, name, associationsModel)]?.presets || []
                     onAddOverride: (preset, index) => {
@@ -284,17 +285,17 @@ KCM.SimpleKCM {
                         } else {
                             associationsModel[asocIndex].presets[index] = preset;
                         }
-                        root.updateConfig();
+                        appearanceRoot.updateConfig();
                     }
                     onRemoveOverride: index => {
                         const asocIndex = Utils.getWidgetConfigIdx(id, name, associationsModel);
                         associationsModel[asocIndex].presets.splice(index, 1);
-                        root.updateConfig();
+                        appearanceRoot.updateConfig();
                     }
                     onClearOverrides: () => {
                         const asocIndex = Utils.getWidgetConfigIdx(id, name, associationsModel);
                         associationsModel[asocIndex].presets = [];
-                        root.updateConfig();
+                        appearanceRoot.updateConfig();
                     }
                 }
             }


### PR DESCRIPTION
- Throttle configuration updates
- Switch font family to ListView as it is significantly faster to load with large amounts of fonts, also put it behind a loader

refs: https://github.com/luisbocanegra/plasma-panel-colorizer/issues/513