### PR TITLE
fix(foreground): propagate theme through containers

### DIFF
--- a/package/contents/ui/code/utils.js
+++ b/package/contents/ui/code/utils.js
@@ -958,10 +958,22 @@ function applyFgColor(
     let maxDepth = depth;
     const forceMask = wRecolorCfg?.method?.mask ?? false;
     const forceEffect = wRecolorCfg?.method?.multiEffect ?? false;
+    const targetTypes = [Text, ToolButton, Label, Canvas, Kirigami.Icon];
+
+    if (isForegroundThemeBoundary(target)) {
+        return {
+            count: count,
+            depth: maxDepth,
+        };
+    }
+    applyForegroundTheme(target, newColor, fgColorCfg);
 
     for (var i = 0; i < target.visibleChildren.length; i++) {
         var child = target.visibleChildren[i];
-        let targetTypes = [Text, ToolButton, Label, Canvas, Kirigami.Icon];
+        if (isForegroundThemeBoundary(child)) {
+            continue;
+        }
+        applyForegroundTheme(child, newColor, fgColorCfg);
         if (
             targetTypes.some(function (type) {
                 return child instanceof type;
@@ -974,12 +986,6 @@ function applyFgColor(
             if (fgColorModified && "color" in child) {
                 child.color = newColor;
             }
-            if (child.Kirigami?.Theme) {
-                child.Kirigami.Theme.textColor = newColor;
-                child.Kirigami.Theme.colorSet =
-                    main.Kirigami.Theme[fgColorCfg.systemColorSet];
-            }
-
             if ("isMask" in child && forceMask) {
                 child.isMask = true;
             }
@@ -1047,6 +1053,19 @@ function applyFgColor(
         count: count,
         depth: maxDepth,
     };
+}
+
+function isForegroundThemeBoundary(item) {
+    return item.Kirigami?.Theme && item.Kirigami.Theme.inherit === false;
+}
+
+function applyForegroundTheme(item, newColor, fgColorCfg) {
+    if (!item.Kirigami?.Theme) {
+        return;
+    }
+
+    item.Kirigami.Theme.textColor = newColor;
+    item.Kirigami.Theme.colorSet = main.Kirigami.Theme[fgColorCfg.systemColorSet];
 }
 
 /**


### PR DESCRIPTION
## Summary

* Apply the configured foreground Kirigami theme color to container items during foreground recoloring.
* Keep foreground recoloring bounded by `Kirigami.Theme.inherit === false` so widgets can explicitly own their own theme subtree.
* Fix global menu labels inheriting a dark text color when the visible item tree contains non-text container nodes.

Fixes #542

## Verification

* `git diff upstream/main...HEAD --check` passed.
* `qmllint package/contents/ui/code/utils.js` passed.
* Local foreground-only build was installed and retested; the global menu black/fuzzy text issue did not reproduce.

## Risk

* This changes foreground theme propagation for recolored item trees.
* Widgets that set `Kirigami.Theme.inherit: false` keep their own theme boundary.
* No migration or configuration changes are required.
