### PR TITLE
fix: don't track last active window by default

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -805,7 +805,7 @@ PlasmoidItem {
         screenGeometry: Plasmoid.containment.screenGeometry
         filterByActive: main.presetAutoloading.filterByActive ?? false
         filterByScreen: main.presetAutoloading.filterByScreen ?? true
-        trackLastActive: main.presetAutoloading.trackLastActive ?? true
+        trackLastActive: main.presetAutoloading.trackLastActive ?? false
     }
 
     RunCommand {


### PR DESCRIPTION
refs: https://github.com/luisbocanegra/plasma-panel-colorizer/issues/553