### PR TITLE
fix!: remove stale blur regions by id

### DIFF
--- a/package/contents/ui/components/CustomBackground.qml
+++ b/package/contents/ui/components/CustomBackground.qml
@@ -389,7 +389,7 @@ Rectangle {
 
     Component.onDestruction: {
         if (main.panelColorizer) {
-            main.panelColorizer.popLastVisibleMaskRegion();
+            main.panelColorizer.removeMaskRegion(maskIndex);
         }
         main.recolorCountChanged.disconnect(recolorTimer.restart);
         main.updateMasks.disconnect(updateMaskDebounced);

--- a/plugin/panelcolorizer.cpp
+++ b/plugin/panelcolorizer.cpp
@@ -87,18 +87,11 @@ void PanelColorizer::combineRegions() {
 
 bool PanelColorizer::hasRegions() const { return !m_mask.isEmpty(); }
 
-void PanelColorizer::popLastVisibleMaskRegion() {
-    if (!m_regions.isEmpty()) {
-        int regionToRemove;
-        for (int i = 0; i < m_regions.size(); i++) {
-            if (m_regions.constFind(i)->second) {
-                regionToRemove = i;
-            }
-        }
-        m_regions.remove(regionToRemove);
+void PanelColorizer::removeMaskRegion(int index) {
+    if (m_regions.remove(index) > 0) {
         combineRegions();
     }
-};
+}
 
 QString PanelColorizer::getIconHash(const QVariant &variant) {
 

--- a/plugin/panelcolorizer.h
+++ b/plugin/panelcolorizer.h
@@ -19,7 +19,7 @@ class PanelColorizer : public QObject {
     Q_INVOKABLE void updatePanelMask(int index, QRectF rect, double topLeftRadius, double topRightRadius,
                                      double bottomLeftRadius, double bottomRightRadius, QPointF offset,
                                      int radiusCompensation, bool visible);
-    Q_INVOKABLE void popLastVisibleMaskRegion();
+    Q_INVOKABLE void removeMaskRegion(int index);
 
     Q_INVOKABLE QString getIconHash(const QVariant &variant);
 


### PR DESCRIPTION
BREAKING CHANGE: The C++ plugins needs to be rebuilt if it was installed manually from source, see https://github.com/luisbocanegra/plasma-panel-colorizer#build-from-source-with-c-plugin