### PR TITLE
feat: update Spanish translation

### DIFF
--- a/package/translate/es.po
+++ b/package/translate/es.po
@@ -94,7 +94,7 @@ msgstr "Panel no encontrado, este widget debe colocarse en un panel para funcion
 
 #: ../contents/ui/components/FontFamilyChooser.qml
 msgid "Search fonts"
-msgstr ""
+msgstr "Buscar fuentes"
 
 #: ../contents/ui/components/FormBorder.qml ../contents/ui/components/FormWidgetSettings.qml
 msgid "Border"
@@ -114,7 +114,7 @@ msgstr "Ancho:"
 
 #: ../contents/ui/components/FormBorder.qml
 msgid "Use an integer when using <strong>Widget Islands</strong> to avoid rendering issues! See <a href=\"%1\">#64</a>."
-msgstr ""
+msgstr "¡Usa un número entero al utilizar <strong>Islas de Widgets<strong> para evitar problemas de renderizado! Ver <a href=\"%1\">#64</a>"
 
 #: ../contents/ui/components/FormBorder.qml
 msgid "Custom widths:"
@@ -334,7 +334,7 @@ msgstr "Fondo"
 
 #: ../contents/ui/components/FormWidgetSettings.qml
 msgid "Disable to make panel fully transparent, removes contrast and blur effects."
-msgstr "Desactiva para hacer el panel totalmente transparente, quita el contraste y el blur"
+msgstr "Desactiva para hacer el panel totalmente transparente, quita el contraste y el desenfoque"
 
 #: ../contents/ui/components/FormWidgetSettings.qml
 msgid "⚠️ Disabling this breaks the panel clickable area and applet dialogs positioning when the panel is in floating mode! See <a href=\"%1\">#80</a>."
@@ -350,7 +350,7 @@ msgstr "Opacidad:"
 
 #: ../contents/ui/components/FormWidgetSettings.qml
 msgid "Set to 0 to keep the mask required for custom background blur."
-msgstr "Establecer en 0 para mantener la máscara requerida para el fondo blur personalizado"
+msgstr "Establecer en 0 para mantener la máscara requerida para el fondo de desenfoque personalizado"
 
 #: ../contents/ui/components/FormWidgetSettings.qml
 msgid "Floating applets:"
@@ -442,11 +442,11 @@ msgstr "Cambiar la apariencia del elemento basado en su estado, esta configuraci
 
 #: ../contents/ui/components/FormWidgetSettings.qml
 msgid "Blur custom background (Beta)"
-msgstr "Fondo blur personalizado (Beta)"
+msgstr "Fondo de desenfoque personalizado (Beta)"
 
 #: ../contents/ui/components/FormWidgetSettings.qml
 msgid "Draw a custom blur mask behind the custom background(s).<br><strong>Native panel background must be enabled with opacity of 0 for this to work as intended.</strong>"
-msgstr "Dibuja una máscara de blur personalizada detrás del fondo o fondos personalizados.<br><strong>El fondo nativo del panel debe estar activado con opacidad 0 para que esto funcione correctamente.</strong>"
+msgstr "Dibuja una máscara de desenfoque personalizada detrás del fondo o fondos personalizados.<br><strong>El fondo nativo del panel debe estar activado con opacidad 0 para que esto funcione correctamente.</strong>"
 
 #: ../contents/ui/components/FormWidgetSettings.qml
 msgid "C++ plugin not found, this feature will not work. Install the plugin and reboot or restart plasmashell to be able to use it. See <a href=\"%1\">install instructions</a>."
@@ -662,7 +662,7 @@ msgstr "¡Gracias por usar %1!"
 
 #: ../contents/ui/components/SupportMe.qml
 msgid "If you enjoy using the plugin please consider sponsoring or donating so I can dedicate more time to maintain and improve this and <a href=\"%1\">my other projects</a>."
-msgstr ""
+msgstr "Si el complemento te resulta útil, por favor considera donar para que pueda dedicar más tiempo a mantener y mejorar este y <a href=\"%1\">mis otros proyectos</a>."
 
 #: ../contents/ui/components/SupportMe.qml
 msgid "You can also"
@@ -686,11 +686,11 @@ msgstr "Bandeja del sistema"
 
 #: ../contents/ui/components/WidgetCardBlacklist.qml
 msgid "Blacklist"
-msgstr "Excluidos"
+msgstr "Excluir"
 
 #: ../contents/ui/components/WidgetCardConfig.qml
 msgid "Clear"
-msgstr ""
+msgstr "Limpiar"
 
 #: ../contents/ui/components/WidgetCardConfig.qml
 msgid "Add"
@@ -722,7 +722,7 @@ msgstr "Actualizar"
 
 #: ../contents/ui/configAppearance.qml
 msgid "Not getting the expected result? Make sure you're editing the correct element.<br>Custom blur not working? Try reinstalling/rebuilding the C++ plugin using the latest source, <a href=\"%1\">see instructions</a>."
-msgstr ""
+msgstr "¿No obtienes el resultado esperado? Asegúrate de estar editando el elemento correcto. ¿El desenfoque personalizado no funciona? Intenta reinstalar/recompilar el complemento C++ usando el código fuente más reciente, <a href=\"%1\">ver instrucciones</a>."
 
 #: ../contents/ui/configAppearance.qml
 msgid "Restore default (removes all customizations)"
@@ -994,7 +994,7 @@ msgstr "Acción:"
 
 #: ../contents/ui/configPresetWidgetOverrides.qml
 msgid "Create configuration overrides and apply them to one or multiple widgets. These overrides should be saved to a preset in <strong>Presets</strong> tab or they will be lost when presets change!"
-msgstr "Crea sobrescrituras de configuración y aplícalas a uno o varios widgets. ¡Estas sobrescrituras deben guardarse en un ajuste de la pestaña <strong>Ajustes preestablecidos</strong> o se perderán cuando cambien los ajustes!"
+msgstr "Crea sobrescrituras de configuración y aplícalas a uno o varios widgets. ¡Estas sobrescrituras deben guardarse en un ajuste de la pestaña <strong>Ajustes</strong> o se perderán cuando cambien los ajustes!"
 
 #: ../contents/ui/configPresetWidgetOverrides.qml
 msgid "Name:"
@@ -1210,7 +1210,7 @@ msgstr "Si tienes D-Bus habilitado, se recomienda usarlo con atajos de teclado e
 
 #: ../contents/ui/configStockPanelSettings.qml
 msgid "D-Bus usage"
-msgstr ""
+msgstr "Uso de D-Bus"
 
 #: ../contents/ui/configTextIconFix.qml
 msgid ""
@@ -1242,19 +1242,19 @@ msgstr "Ordenar"
 
 #: ../contents/ui/configTrayIconsReplacer.qml
 msgid "Replace System Tray icons with icons from the current icon theme or a local file. The built-in rules icons are part of <a href=\"%1\">Papirus icon theme</a>."
-msgstr ""
+msgstr "Reemplaza los iconos de la bandeja del sistema con iconos del tema de iconos actual o un archivo local. Los iconos de las reglas integradas forman parte del <a href=\"%1\">tema de iconos Papirus</a>."
 
 #: ../contents/ui/configTrayIconsReplacer.qml
 msgid "C++ plugin not found, this feature will not work. Install the plugin and reboot or restart plasmashell to be able to use it <a href=\"%1\">Install instructions</a>."
-msgstr ""
+msgstr "No se encontró el complemento de C++, esta función no estará disponible. Instala el complemento y reinicia el sistema o plasmashell para poder utilizarla. <a href=\"%1\">Instrucciones de instalación</a>."
 
 #: ../contents/ui/configTrayIconsReplacer.qml
 msgid "The installed version of the C++ plugin doesn't support this feature, update the plugin and reboot or restart plasmashell to be able to use it <a href=\"%1\">Install instructions</a>."
-msgstr ""
+msgstr "La versión instalada del complemento de C++ no admite esta función, actualiza el complemento y reinicia el sistema o plasmashell para poder utilizarla. <a href=\"%1\">Instrucciones de instalación</a>."
 
 #: ../contents/ui/configTrayIconsReplacer.qml
 msgid "Log icon changes:"
-msgstr "Registrar cambios de iconos:"
+msgstr "Registrar cambios de icono:"
 
 #: ../contents/ui/configTrayIconsReplacer.qml
 msgid "Icon hashes will be printed to the system log"
@@ -1274,23 +1274,23 @@ msgstr "Cómo usar"
 
 #: ../contents/ui/configTrayIconsReplacer.qml
 msgid "1. Enable <b>Log icon changes</b> above<br>2. Run <b>journalctl -f</b> from terminal<br>3. Hover the System tray entry or trigger an icon change<br>4. Copy one of the properties: icon SHA1, icon name, name or title<br>5. Add a new rule with the matching property you choose and specify the replacement icon name or file"
-msgstr ""
+msgstr "1. Active <b>Registrar cambios de icono</b> más arriba<br>2. Ejecute <b>journalctl -f</b> desde la terminal<br>3. Pase el cursor sobre la entrada de la bandeja del sistema o provoque un cambio de icono<br>4. Copie una de las propiedades: SHA1 del icono, nombre del icono, nombre o título<br>5. Añada una nueva regla con la propiedad coincidente que elija y especifique el icono o archivo de reemplazo"
 
 #: ../contents/ui/configTrayIconsReplacer.qml
 msgid "<b>Note</b>: There are some rules without icon as there was no matching one in Papirus, you can override those with your own icons by copying the rule to <b>User Replacements</b>"
-msgstr ""
+msgstr "<b>Nota</b>: Hay algunas reglas sin icono ya que no había uno coincidente en Papirus, puede sobrescribirlas con sus propios iconos copiando la regla a <b>Reemplazos de usuario</b>"
 
 #: ../contents/ui/configTrayIconsReplacer.qml
 msgid "<b>Note</b>: Some applications like Signal are missing accumulated notification icons, contribution of missing icons via GitHub pull request or issue is very welcome, please do so by providing the the description + icon SHA1/icon name/title/name + icon-name from Papirus (panel/status icons only if no matching icon exists, otherwise it can be omitted)"
-msgstr ""
+msgstr "<b>Nota</b>: Algunas aplicaciones como Signal carecen de iconos de notificación acumulados; se agradece mucho la contribución de los iconos faltantes mediante una pull request o un issue en GitHub, indicando la descripción + SHA1 del icono/nombre del icono/título/nombre + el nombre del icono de Papirus (solo iconos de panel/estado, si no existe un icono coincidente; en caso contrario, puede omitirse)"
 
 #: ../contents/ui/configTrayIconsReplacer.qml
 msgid "<b>Note</b>: Matching properties (especially the SHA1) may change when applications get updated, rules will need to be updated when that happens."
-msgstr ""
+msgstr "<b>Nota</b>: Las propiedades (especialmente el SHA1) pueden cambiar cuando las aplicaciones se actualizan, las reglas deberán actualizarse cuando eso ocurra."
 
 #: ../contents/ui/configTrayIconsReplacer.qml
 msgid "<b>Note</b>: Plasma widgets in the system tray are not supported by this feature as widgets provide their own visual content and logic."
-msgstr ""
+msgstr "<b>Nota</b>: Los widgets de Plasma en la bandeja del sistema no son compatibles con esta función, ya que los widgets proporcionan su propia lógica y contenido visual."
 
 #: ../contents/ui/configTrayIconsReplacer.qml
 msgid "Built-in Rules (read only)"
@@ -1348,7 +1348,7 @@ msgstr "Copiar a Reglas de usuario"
 
 #: ../contents/ui/configTrayIconsReplacer.qml
 msgid "Duplicate rule"
-msgstr ""
+msgstr "Duplicar regla"
 
 #: ../contents/ui/configWidgetIslands.qml
 msgid "Create widget islands by placing separator widgets around them."
@@ -1356,7 +1356,7 @@ msgstr "Crea islas de widgets colocando widgets separadores a su alrededor."
 
 #: ../contents/ui/configWidgetIslands.qml
 msgid "<strong>How to use</strong><br>1. Add the widget that will act as islands separator to the panel(by default the Plasma's Panel Spacer widget will be used)<br>2. Select the separator widget below<br>3. Add as many separators as you need and move them to create islands."
-msgstr "<strong>Modo de uso</strong><br>1. Añade al panel el widget que servirá como separador de islas (por defecto se usará el Espaciador del panel de Plasma)<br>2. Selecciona el widget separador a continuación<br>3. Añade tantos separadores como necesites y muévelos para crear las islas."
+msgstr "<strong>Modo de uso</strong><br>1. Añade al panel el widget que servirá como separador de islas (por defecto se usará el Espaciador del panel de Plasma).<br>2. Selecciona el widget separador a continuación.<br>3. Añade tantos separadores como necesites y muévelos para crear las islas."
 
 #: ../contents/ui/configWidgetIslands.qml
 msgid "<strong>Notes</strong><br>- Widget custom background or border is required for this option to have a visible effect.<br>- If the widgets in your panel have different thickness, add margins to the widgets custom background in the Appearance tab."
@@ -1388,7 +1388,7 @@ msgstr ""
 
 #: ../contents/ui/configWidgetIslands.qml
 msgid "Blacklist separator widgets:"
-msgstr "Lista negra de widgets separadores:"
+msgstr "Añadir separadores a los widgets excluidos:"
 
 #: ../contents/ui/configWidgetIslands.qml
 msgid "Disable customization from separator widgets"
@@ -1396,7 +1396,7 @@ msgstr "Desactivar personalización de los widgets separadores"
 
 #: ../contents/ui/main.qml
 msgid "This widget must be placed in a panel to work!"
-msgstr ""
+msgstr "¡Este widget debe colocarse en un panel para funcionar!"
 
 #: ../contents/ui/main.qml
 msgid "Hide widget (visible in panel Edit Mode)"
@@ -1404,7 +1404,7 @@ msgstr "Ocultar widget (visible en el Modo edición del panel)"
 
 #: ../contents/ui/main.qml
 msgid "A Plasmashell restart is required to remove all the modifications made by %1. Run systemctl restart --user plasma-plasmashell or log out and log back in."
-msgstr ""
+msgstr "Se requiere reiniciar Plasmashell para eliminar todas las modificaciones realizadas por %1. Ejecute systemctl restart --user plasma-plasmashell o cierre sesión y vuelva a iniciarla."
 
 #~ msgid "Use an integer when using <strong>Widget Islands</strong> to avoid rendering issues! <a href=\"https://github.com/luisbocanegra/plasma-panel-colorizer/issues/64\">See #64</a>"
 #~ msgstr "¡Usa números enteros al utilizar <strong>Islas de Widgets</strong> para evitar problemas de renderizado! <a href=\"https://github.com/luisbocanegra/plasma-panel-colorizer/issues/64\">Más información #64</a>"


### PR DESCRIPTION
I've updated the Spanish translation for version 8.0.0.

I'd like to clear up something for the next update of this translation. On line 1276 it says the following:

`[...] 4. Copy any of the properties: icon SHA1/name, title or name <br>5. Add a new rule with the SHA1/icon name/title/name you choose and specify the custom [...]`

I'm a bit confused by _"SHA1/name"_, then _"SHA1/icon"_, and the _"name/title/name"_ part. Since I wasn't sure, I went ahead and translated it fairly literally. Could you let me know if the original text is worded correctly and I should follow it as is? Thanks!